### PR TITLE
Refactor vision pipeline configuration layers

### DIFF
--- a/Server/core/vision/dynamic_adjuster.py
+++ b/Server/core/vision/dynamic_adjuster.py
@@ -1,0 +1,63 @@
+import cv2
+import numpy as np
+from dataclasses import dataclass
+from typing import Tuple, Optional
+
+NDArray = np.ndarray
+
+def _pct_on(mask: NDArray) -> float:
+    return 100.0 * float((mask > 0).sum()) / float(mask.size)
+
+def _adaptive_thresh(gray: NDArray) -> NDArray:
+    return cv2.adaptiveThreshold(
+        gray, 255, cv2.ADAPTIVE_THRESH_MEAN_C, cv2.THRESH_BINARY_INV, 11, 2
+    )
+
+@dataclass
+class CannyConfig:
+    t1_init: float = 50.0
+    t2_ratio: float = 2.5
+    life_min: float = 5.0
+    life_max: float = 10.0
+    rescue_life_min: float = 3.0
+    kp: float = 4.0
+    max_iter: int = 25
+
+class DynamicAdjuster:
+    """Auto-Canny and rescue logic applied before detection."""
+    def __init__(self, cfg: Optional[CannyConfig] = None) -> None:
+        self.cfg = cfg if cfg is not None else CannyConfig()
+
+    def update(self, **kwargs) -> None:
+        """Update configuration values at runtime."""
+        for k, v in kwargs.items():
+            if hasattr(self.cfg, k):
+                current = getattr(self.cfg, k)
+                try:
+                    setattr(self.cfg, k, type(current)(v))
+                except Exception:
+                    setattr(self.cfg, k, v)
+
+    def apply(self, gray: NDArray) -> Tuple[NDArray, NDArray, float, int, float, bool]:
+        """Return (edges, canny, t1, t2, life, used_rescue)."""
+        cfg = self.cfg
+        t1 = float(cfg.t1_init)
+        life = 0.0
+        for _ in range(1, cfg.max_iter + 1):
+            t2 = int(np.clip(cfg.t2_ratio * t1, 0, 255))
+            canny = cv2.Canny(gray, int(max(0, t1)), int(t2))
+            life = _pct_on(canny)
+            if cfg.life_min <= life <= cfg.life_max:
+                break
+            if life < cfg.life_min:
+                t1 = max(1.0, t1 - cfg.kp * (cfg.life_min - life))
+            else:
+                t1 = min(220.0, t1 + cfg.kp * (life - cfg.life_max))
+        t2 = int(np.clip(cfg.t2_ratio * t1, 0, 255))
+        used_rescue = False
+        edges = canny.copy()
+        if life < cfg.rescue_life_min:
+            th = _adaptive_thresh(gray)
+            edges = cv2.bitwise_or(canny, th)
+            used_rescue = True
+        return edges, canny, float(t1), int(t2), float(life), bool(used_rescue)

--- a/Server/core/vision/profile_manager.py
+++ b/Server/core/vision/profile_manager.py
@@ -1,0 +1,107 @@
+import json
+from typing import Optional, Dict, Any
+
+from .detectors.contour_detector import (
+    ProcConfig,
+    MorphConfig,
+    GeoFilters,
+    Weights,
+    PreMorphPatches,
+    ColorGateConfig,
+)
+from .dynamic_adjuster import CannyConfig
+
+class ProfileManager:
+    """Load detector and adjuster configuration from JSON profiles."""
+    def __init__(self, path: str) -> None:
+        self.path = path
+        self.load()
+
+    def load(self) -> None:
+        with open(self.path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        self.proc = ProcConfig(
+            proc_w=int(data.get("PROC_W", ProcConfig().proc_w)),
+            proc_h=int(data.get("PROC_H", ProcConfig().proc_h)),
+            blur_k=int(data.get("BLUR_K", ProcConfig().blur_k)),
+            border_margin=int(data.get("BORDER_MARGIN", ProcConfig().border_margin)),
+        )
+        self.canny = CannyConfig(
+            t1_init=float(data.get("T1_INIT", CannyConfig().t1_init)),
+            t2_ratio=float(data.get("T2_RATIO", CannyConfig().t2_ratio)),
+            life_min=float(data.get("life_MIN", CannyConfig().life_min)),
+            life_max=float(data.get("life_MAX", CannyConfig().life_max)),
+            rescue_life_min=float(data.get("RESCUE_life_MIN", CannyConfig().rescue_life_min)),
+            kp=float(data.get("Kp", CannyConfig().kp)),
+            max_iter=int(data.get("MAX_ITER", CannyConfig().max_iter)),
+        )
+        self.morph = MorphConfig(
+            close_min=int(data.get("CLOSE_MIN", MorphConfig().close_min)),
+            close_max=int(data.get("CLOSE_MAX", MorphConfig().close_max)),
+            dil_min=int(data.get("DIL_MIN", MorphConfig().dil_min)),
+            dil_max=int(data.get("DIL_MAX", MorphConfig().dil_max)),
+            steps=int(data.get("MORPH_STEPS", MorphConfig().steps)),
+        )
+        self.geo = GeoFilters(
+            ar_min=float(data.get("AR_MIN", GeoFilters().ar_min)),
+            ar_max=float(data.get("AR_MAX", GeoFilters().ar_max)),
+            bbox_hard_cap=float(data.get("BBOX_HARD_CAP", GeoFilters().bbox_hard_cap)),
+            bbox_min=float(data.get("BBOX_MIN", GeoFilters().bbox_min)),
+            bbox_max=float(data.get("BBOX_MAX", GeoFilters().bbox_max)),
+            fill_min=float(data.get("FILL_MIN", GeoFilters().fill_min)),
+            fill_max=float(data.get("FILL_MAX", GeoFilters().fill_max)),
+            min_area_frac=float(data.get("MIN_AREA_FRAC", GeoFilters().min_area_frac)),
+        )
+        self.w = Weights(
+            area=float(data.get("W_AREA", Weights().area)),
+            fill=float(data.get("W_FILL", Weights().fill)),
+            solidity=float(data.get("W_SOLI", Weights().solidity)),
+            circular=float(data.get("W_CIRC", Weights().circular)),
+            rect=float(data.get("W_RECT", Weights().rect)),
+            ar=float(data.get("W_AR", Weights().ar)),
+            center_bias=float(data.get("CENTER_BIAS", Weights().center_bias)),
+            dist=float(data.get("W_DIST", Weights().dist)),
+        )
+        self.premorph = PreMorphPatches(
+            bottom_margin_pct=int(data.get("BOTTOM_MARGIN_PCT", PreMorphPatches().bottom_margin_pct)),
+            min_blob_px=int(data.get("MIN_BLOB_PX", PreMorphPatches().min_blob_px)),
+            fill_from_edges=bool(data.get("FILL_FROM_EDGES", PreMorphPatches().fill_from_edges)),
+        )
+        cg = data.get("COLOR_GATE", {}) or {}
+        hsv = cg.get("hsv", {})
+        self.color = ColorGateConfig(
+            enabled=bool(cg.get("enable", False)),
+            mode=str(cg.get("mode", "lab_bg")),
+            ab_thresh=int(cg.get("lab", {}).get("ab_thresh", ColorGateConfig().ab_thresh)),
+            hsv_lo=(
+                int(hsv.get("h_low", ColorGateConfig().hsv_lo[0])),
+                int(hsv.get("s_min", ColorGateConfig().hsv_lo[1])),
+                int(hsv.get("v_min", ColorGateConfig().hsv_lo[2])),
+            ),
+            hsv_hi=(
+                int(hsv.get("h_high", ColorGateConfig().hsv_hi[0])),
+                ColorGateConfig().hsv_hi[1],
+                ColorGateConfig().hsv_hi[2],
+            ),
+            combine=str(cg.get("combine", ColorGateConfig().combine)),
+            min_cover_pct=float(cg.get("min_cover_pct", ColorGateConfig().min_cover_pct)),
+            max_cover_pct=float(cg.get("max_cover_pct", ColorGateConfig().max_cover_pct)),
+        )
+
+    def reload(self, path: Optional[str] = None) -> None:
+        if path:
+            self.path = path
+        self.load()
+
+    def get_detector_config(self) -> Dict[str, Any]:
+        return dict(
+            proc=self.proc,
+            morph=self.morph,
+            geo=self.geo,
+            w=self.w,
+            premorph=self.premorph,
+            color=self.color,
+        )
+
+    def get_canny_config(self) -> CannyConfig:
+        return self.canny

--- a/Server/network/ws_server.py
+++ b/Server/network/ws_server.py
@@ -1,10 +1,11 @@
 import asyncio
-import websockets
 import socket
 import json
 import time
+import websockets
 
 from core.Camera import Camera
+from core.vision import api as vision_api
 
 camera = Camera()
 camera.start_periodic_capture(interval=1.0)  # sigue autoarrancando; si prefieres lazy, quita esta línea
@@ -64,6 +65,18 @@ async def handler(websocket):
                 camera.set_processing_config(config)
                 response = {"status": "ok", "type": "text", "data": "processing config updated"}
 
+            elif cmd == "load_profile":
+                which = data.get("which", "big")
+                path = data.get("path")
+                vision_api.load_profile(which, path)
+                response = {"status": "ok", "type": "text", "data": f"profile {which} loaded"}
+
+            elif cmd == "dynamic":
+                which = data.get("which", "big")
+                params = data.get("params", {})
+                vision_api.update_dynamic(which, params)
+                response = {"status": "ok", "type": "text", "data": "dynamic params updated"}
+
             else:
                 response = {"status": "error", "type": "text", "data": f"unknown command: {cmd}"}
 
@@ -88,3 +101,4 @@ async def start_ws_server_async():
 
 def start_ws_server():
     asyncio.run(start_ws_server_async())
+


### PR DESCRIPTION
## Summary
- decouple static and dynamic detector configuration
- expose profile reloading and dynamic knob updates through API and websocket
- move auto-canny lifecycle to dedicated DynamicAdjuster

## Testing
- `python -m py_compile Server/core/vision/dynamic_adjuster.py Server/core/vision/profile_manager.py Server/core/vision/detectors/contour_detector.py Server/core/vision/api.py Server/network/ws_server.py`
- `pip install numpy --quiet` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689e1aac3044832ea0a3bf2a15fbb29d