### PR TITLE
refactor: consolidate vision utils as imgproc with docs

### DIFF
--- a/Server/core/vision/api.py
+++ b/Server/core/vision/api.py
@@ -26,7 +26,7 @@ import os
 from .detectors.contour_detector import ContourDetector, DetectionResult, configs_from_profile
 from .profile_manager import load_profile as pm_load_profile, get_config
 from .dynamic_adjuster import DynamicAdjuster
-from .vision_utils import mask_to_roi
+from .imgproc import mask_to_roi
 from .config_defaults import (
     DEFAULT_STABLE,
     DEFAULT_ON_THRESHOLD,

--- a/Server/core/vision/detectors/contour_detector.py
+++ b/Server/core/vision/detectors/contour_detector.py
@@ -44,7 +44,7 @@ from ..config_defaults import (
     COLORGATE_MAX_COVER_PCT,
     BOTTOM_MARGIN_MAX,
 )
-from ..vision_utils import (
+from ..imgproc import (
     pct_on,
     despeckle,
     _preprocess,

--- a/Server/core/vision/dynamic_adjuster.py
+++ b/Server/core/vision/dynamic_adjuster.py
@@ -14,7 +14,7 @@ from .config_defaults import (
     ADAPTIVE_BLOCK_SIZE,
     ADAPTIVE_C,
 )
-from .vision_utils import pct_on
+from .imgproc import pct_on
 
 NDArray = np.ndarray
 


### PR DESCRIPTION
## Summary
- rename vision_utils module to imgproc
- document all image processing helpers with Doxygen-style docstrings
- update imports to use new imgproc module

## Testing
- `python -m py_compile Server/core/vision/imgproc.py Server/core/vision/dynamic_adjuster.py Server/core/vision/api.py Server/core/vision/detectors/contour_detector.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'network')*

------
https://chatgpt.com/codex/tasks/task_e_689ed1a4514c832eaf12feb60bea2a42