### PR TITLE
Add pytest scaffolding for server test scripts

### DIFF
--- a/tests/test_gamepad.py
+++ b/tests/test_gamepad.py
@@ -1,0 +1,8 @@
+import pytest
+
+Gamepad = pytest.importorskip("Gamepad")
+pytest.importorskip("Server.core.Action")
+
+
+def test_gamepad_has_xbox360():
+    assert hasattr(Gamepad, "Xbox360")

--- a/tests/test_hello_world.py
+++ b/tests/test_hello_world.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+def test_action_module_available():
+    """Ensure Action module is importable via package path."""
+    pytest.importorskip("Server.core.Action")

--- a/tests/test_led.py
+++ b/tests/test_led.py
@@ -1,0 +1,7 @@
+import pytest
+
+led_module = pytest.importorskip("Server.core.led.led")
+
+
+def test_led_class_exists():
+    assert hasattr(led_module, "Led")

--- a/tests/test_led_controller.py
+++ b/tests/test_led_controller.py
@@ -1,0 +1,7 @@
+import pytest
+
+led_controller_module = pytest.importorskip("Server.core.LedController")
+
+
+def test_led_controller_class_exists():
+    assert hasattr(led_controller_module, "LedController")

--- a/tests/test_llm_tts.py
+++ b/tests/test_llm_tts.py
@@ -1,0 +1,6 @@
+from pathlib import Path
+
+
+def test_llm_to_tts_script_exists():
+    path = Path("Server/core/llm/llm_to_tts.py")
+    assert path.is_file()

--- a/tests/test_visual_perception.py
+++ b/tests/test_visual_perception.py
@@ -1,0 +1,7 @@
+import pytest
+
+camera_module = pytest.importorskip("Server.core.Camera")
+
+
+def test_camera_class_exists():
+    assert hasattr(camera_module, "Camera")

--- a/tests/test_voice_interface.py
+++ b/tests/test_voice_interface.py
@@ -1,0 +1,7 @@
+import pytest
+
+voice_module = pytest.importorskip("Server.core.Voice_interface")
+
+
+def test_conversation_manager_exists():
+    assert hasattr(voice_module, "ConversationManager")

--- a/tests/test_voice_loop.py
+++ b/tests/test_voice_loop.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+
+
+def test_voice_loop_scripts_exist():
+    root = Path("Server/core/llm")
+    assert (root / "llm_to_tts.py").is_file()
+    assert (root / "stt.py").is_file()

--- a/tests/test_ws_server.py
+++ b/tests/test_ws_server.py
@@ -1,0 +1,7 @@
+import pytest
+
+ws_module = pytest.importorskip("Server.network.ws_server")
+
+
+def test_ws_server_start_exists():
+    assert hasattr(ws_module, "start_ws_server")


### PR DESCRIPTION
## Summary
- add tests/ directory with pytest-based wrappers for existing test scripts
- ensure modules are imported via `Server` package and hardware-heavy tests skip when dependencies missing
- include basic checks for presence of LLM and STT scripts

## Testing
- `pip install pytest`
- `pytest tests/`

------
https://chatgpt.com/codex/tasks/task_e_68ab5d9986f0832eb9040c006a930595