### PR TITLE
Refactor websocket client to async with context manager

### DIFF
--- a/Client/network/ws_client.py
+++ b/Client/network/ws_client.py
@@ -1,52 +1,66 @@
-import asyncio
+import os
 import json
-import threading
 import websockets
 
-SERVER_URI = "ws://192.168.1.133:8765"
 
 class WebSocketClient:
-    def __init__(self):
-        self.uri = SERVER_URI
+    """Simple asynchronous WebSocket client.
+
+    The server URI can be provided either as a constructor argument or
+    through the ``SERVER_URI`` environment variable.  If neither is
+    supplied, ``ws://192.168.1.133:8765`` is used as a fallback.
+
+    The client exposes :func:`connect`, :func:`send_command` and
+    :func:`close` coroutines and implements the asynchronous context
+    manager protocol so it can be used with ``async with``.
+    """
+
+    DEFAULT_URI = "ws://192.168.1.133:8765"
+
+    def __init__(self, uri: str | None = None):
+        # Environment variable takes precedence over the hard coded default
+        env_uri = os.getenv("SERVER_URI")
+        self.uri = uri or env_uri or self.DEFAULT_URI
         self.websocket = None
-        self.loop = asyncio.new_event_loop()
-        self.thread = threading.Thread(target=self._start_loop, daemon=True)
         self.connected = False
-        self.lock = threading.Lock()
-        self.thread.start()
 
-    def _start_loop(self):
-        asyncio.set_event_loop(self.loop)
-        self.loop.run_forever()
-
-    async def _connect(self):
+    async def connect(self):
+        """Establish a websocket connection to ``self.uri``."""
         try:
             self.websocket = await websockets.connect(self.uri)
             self.connected = True
             print("[WebSocketClient] Connected.")
-        except Exception as e:
+        except Exception as e:  # pragma: no cover - defensive branch
             print(f"[WebSocketClient] Connection failed: {e}")
             self.connected = False
 
-    async def _send_command(self, command):
+    async def send_command(self, command):
+        """Send ``command`` and wait for the server response."""
         if not self.connected:
-            await self._connect()
-        if not self.connected:
+            await self.connect()
+        if not self.connected:  # connection failed
             return None
         try:
             await self.websocket.send(json.dumps(command))
             response = await self.websocket.recv()
             return json.loads(response)
-        except Exception as e:
+        except Exception as e:  # pragma: no cover - defensive branch
             print(f"[WebSocketClient] Error during send/receive: {e}")
             return None
 
-    def send_command(self, command):
-        future = asyncio.run_coroutine_threadsafe(self._send_command(command), self.loop)
-        return future.result(timeout=5)
-
-    def close(self):
+    async def close(self):
+        """Close the websocket connection."""
         if self.websocket:
-            close_future = asyncio.run_coroutine_threadsafe(self.websocket.close(), self.loop)
-            close_future.result(timeout=5)
-        self.loop.call_soon_threadsafe(self.loop.stop)
+            await self.websocket.close()
+            self.websocket = None
+        self.connected = False
+
+    # ------------------------------------------------------------------
+    # Async context manager protocol
+    async def __aenter__(self):
+        await self.connect()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        await self.close()
+

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+testpaths =
+    tests
+markers =
+    asyncio: mark tests as requiring asyncio
+

--- a/tests/test_ws_client_async.py
+++ b/tests/test_ws_client_async.py
@@ -1,0 +1,87 @@
+import asyncio
+import json
+import sys
+from pathlib import Path
+import types
+
+# Ensure project root on path and provide a dummy ``websockets`` module so
+# the client can be imported without the real dependency.
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+sys.modules.setdefault("websockets", types.SimpleNamespace())
+
+
+def test_env_uri_and_context_manager(monkeypatch):
+    from Client.network import ws_client
+
+    class DummyWebSocket:
+        def __init__(self):
+            self.sent = []
+            self.closed = False
+
+        async def send(self, data):
+            self.sent.append(data)
+
+        async def recv(self):
+            return json.dumps({"status": "ok"})
+
+        async def close(self):
+            self.closed = True
+
+    dummy_ws = DummyWebSocket()
+
+    async def fake_connect(uri):
+        assert uri == "ws://dummy"
+        return dummy_ws
+
+    monkeypatch.setenv("SERVER_URI", "ws://dummy")
+    monkeypatch.setattr(ws_client.websockets, "connect", fake_connect, raising=False)
+
+    async def runner():
+        async with ws_client.WebSocketClient() as client:
+            response = await client.send_command({"cmd": "ping"})
+        return response
+
+    response = asyncio.run(runner())
+
+    assert response == {"status": "ok"}
+    assert dummy_ws.sent == [json.dumps({"cmd": "ping"})]
+    assert dummy_ws.closed is True
+
+
+def test_parameter_uri_and_manual_start_stop(monkeypatch):
+    from Client.network import ws_client
+
+    class DummyWebSocket:
+        def __init__(self):
+            self.closed = False
+
+        async def send(self, data):
+            self.data = data
+
+        async def recv(self):
+            return json.dumps({"status": "ok"})
+
+        async def close(self):
+            self.closed = True
+
+    dummy_ws = DummyWebSocket()
+
+    async def fake_connect(uri):
+        assert uri == "ws://param"
+        return dummy_ws
+
+    monkeypatch.setattr(ws_client.websockets, "connect", fake_connect, raising=False)
+
+    async def runner():
+        client = ws_client.WebSocketClient("ws://param")
+        await client.connect()
+        response = await client.send_command({"cmd": "ping"})
+        await client.close()
+        return response
+
+    response = asyncio.run(runner())
+
+    assert response == {"status": "ok"}
+    assert dummy_ws.data == json.dumps({"cmd": "ping"})
+    assert dummy_ws.closed is True
+


### PR DESCRIPTION
## Summary
- refactor WebSocketClient to accept server URI via env or constructor
- expose async connect/send_command APIs with async context manager
- add tests for WebSocketClient and configure pytest to run only tests directory

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab60ffe094832ea882ef956706deca