### PR TITLE
Inject stream service into GUI

### DIFF
--- a/Client/gui/main_window.py
+++ b/Client/gui/main_window.py
@@ -1,19 +1,21 @@
 import sys
 from PyQt6.QtWidgets import QApplication, QMainWindow, QVBoxLayout, QWidget
 from gui.widgets.stream_widget import StreamWidget
+from gui.services.stream_service import StreamService
 from network.ws_client import WebSocketClient
 
 class ImageStreamViewer(QMainWindow):
-    def __init__(self):
+    def __init__(self, stream_service: StreamService | None = None):
         super().__init__()
         self.setWindowTitle("Robot Viewer")
         self.resize(800, 600)
 
-        self.ws_client = WebSocketClient()
+        # Allow the caller to provide a custom service (e.g. a mock for tests).
+        self.stream_service = stream_service or StreamService(WebSocketClient())
 
         widget = QWidget()
         layout = QVBoxLayout()
-        layout.addWidget(StreamWidget(self.ws_client))
+        layout.addWidget(StreamWidget(self.stream_service))
         widget.setLayout(layout)
 
         self.setCentralWidget(widget)

--- a/Client/gui/services/stream_service.py
+++ b/Client/gui/services/stream_service.py
@@ -1,0 +1,31 @@
+import asyncio
+
+class StreamService:
+    """High-level interface to fetch images from the server.
+
+    The service delegates low-level communication to the provided
+    ``client`` object which is expected to expose a ``send_command``
+    coroutine or method.
+    """
+
+    def __init__(self, client):
+        self.client = client
+
+    def fetch_image(self):
+        """Request a single image frame from the server.
+
+        Returns the base64-encoded image data or ``None`` if the request
+        fails.
+        """
+        send = getattr(self.client, "send_command", None)
+        if send is None:
+            return None
+
+        if asyncio.iscoroutinefunction(send):
+            response = asyncio.run(send({"cmd": "capture"}))
+        else:
+            response = send({"cmd": "capture"})
+
+        if response and response.get("status") == "ok":
+            return response.get("data")
+        return None


### PR DESCRIPTION
## Summary
- add `StreamService` to wrap low-level websocket commands
- have `StreamWidget` pull images via injected service
- allow `ImageStreamViewer` to accept custom services for easier testing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab62d0a0c4832ea7a1eff1d3c5f944