### PR TITLE
Add unit tests for core vision, voice, and LLM components

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,7 @@
 [pytest]
+pythonpath =
+    .
+    Server
 testpaths =
     tests
     tests/client

--- a/tests/test_mock_client.py
+++ b/tests/test_mock_client.py
@@ -1,0 +1,9 @@
+from tests.mock_llm import MockClient
+
+
+def test_mock_client_postprocess():
+    client = MockClient(prefix="> ")
+    messages = [{"role": "user", "content": "hello world"}]
+    reply = client.query(messages, max_chars=5)
+    assert reply == "> hello"
+    assert client.queries == [(messages, 5)]

--- a/tests/test_process_frame.py
+++ b/tests/test_process_frame.py
@@ -1,0 +1,53 @@
+import sys
+import types
+
+numpy_stub = types.ModuleType("numpy")
+class _NDArray:  # minimal placeholder
+    pass
+numpy_stub.ndarray = _NDArray
+sys.modules.setdefault("numpy", numpy_stub)
+sys.modules.setdefault("cv2", types.ModuleType("cv2"))
+
+from core.vision.system import VisionSystem
+
+
+def test_process_frame_detector_selection(monkeypatch):
+    vs = VisionSystem()
+
+    # Avoid initializing real detectors
+    monkeypatch.setattr(vs, "_ensure_detectors", lambda: None)
+    calls = []
+
+    def fake_step(det, which, frame, return_overlay):
+        calls.append(which)
+        px = int(frame[0][0][0])
+        if which == "big":
+            if px == 1:
+                return True, {"ok": True, "score": 0.9}
+            return False, {"ok": False, "score": 0.4}
+        else:  # small detector
+            if px == 2:
+                return True, {"ok": True, "score": 0.8}
+            return False, {"ok": False, "score": 0.5}
+
+    monkeypatch.setattr(vs, "_step", fake_step)
+
+    # Big detector succeeds
+    frame_big = [[[1]]]
+    out = vs.process_frame(frame_big)
+    assert out["score"] == 0.9
+    assert calls == ["big"]
+
+    # Small detector used when big fails
+    calls.clear()
+    frame_small = [[[2]]]
+    out = vs.process_frame(frame_small)
+    assert out["score"] == 0.8
+    assert calls == ["big", "small"]
+
+    # Choose detector with higher score when both fail
+    calls.clear()
+    frame_none = [[[0]]]
+    out = vs.process_frame(frame_none)
+    assert out["score"] == 0.5
+    assert calls == ["big", "small"]

--- a/tests/test_voice_conversation.py
+++ b/tests/test_voice_conversation.py
@@ -1,0 +1,73 @@
+import sys
+import types
+
+# Provide stub for optional dependency
+sys.modules.setdefault("requests", types.ModuleType("requests"))
+
+from core.voice.speech_input import SpeechInput
+from core.voice.speech_output import SpeechOutput, TTSInterface, LEDInterface
+from core.voice.conversation import ConversationManager
+from core.voice import VoiceInterface
+from tests.mock_llm import MockClient
+
+
+class FakeSTT(SpeechInput):
+    def __init__(self, utterances):
+        self._utter = iter(utterances)
+        self.pause_calls = 0
+        self.resume_calls = 0
+
+    def start(self) -> None:
+        pass
+
+    def pause(self) -> None:
+        self.pause_calls += 1
+
+    def resume(self) -> None:
+        self.resume_calls += 1
+
+    def stop(self) -> None:
+        pass
+
+    def stream(self):
+        for u in self._utter:
+            yield u
+
+
+class FakeLED(LEDInterface):
+    def __init__(self):
+        self.states = []
+
+    def set_state(self, state: str) -> None:
+        self.states.append(state)
+
+
+class FakeTTS(TTSInterface):
+    def __init__(self):
+        self.spoken = []
+
+    def say(self, text: str) -> None:
+        self.spoken.append(text)
+
+
+def test_wake_word_and_state_changes():
+    llm = MockClient()
+    conv = ConversationManager(llm, wake_words=["robot"])
+
+    # No wake word -> no reply
+    assert conv.process("hello") is None
+
+    stt = FakeSTT(["hello robot"])
+    leds = FakeLED()
+    tts = FakeTTS()
+    output = SpeechOutput(tts, leds)
+    iface = VoiceInterface(stt, conv, output)
+
+    iface.start()
+    iface._thread.join(timeout=1)
+    iface.stop()
+
+    assert leds.states == ["wake", "listen", "speaking", "wake"]
+    assert tts.spoken == ["ACK: hello robot"]
+    assert stt.pause_calls == 1
+    assert stt.resume_calls == 1


### PR DESCRIPTION
## Summary
- add tests for `VisionSystem.process_frame` using mocked detectors
- test voice conversation with simulated STT/TTS and wake word handling
- validate `MockClient` response postprocessing
- configure `pytest.ini` with project-relative import paths

## Testing
- `pytest tests/test_process_frame.py tests/test_voice_conversation.py tests/test_mock_client.py -vv`
- `pytest tests` *(fails: ModuleNotFoundError: No module named 'numpy'; No module named 'requests')*
- `pip install numpy` *(failed: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ab788f9e64832e8902d98ea07b3832