### PR TITLE
feat(server): modularize systems

### DIFF
--- a/Server/__init__.py
+++ b/Server/__init__.py
@@ -1,0 +1,1 @@
+"""Top-level package for server components."""

--- a/Server/app.py
+++ b/Server/app.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+"""Application helpers to start and configure server subsystems."""
+
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from .core.voice import (
+    ConversationManager,
+    HTTPClient,
+    SpeechOutput,
+    SubprocessSpeechInput,
+    SubprocessTTS,
+    VoiceInterface,
+)
+from .core.vision.system import VisionSystem
+
+BASE_DIR = Path(__file__).resolve().parent
+
+
+def start_voice(config: Optional[Dict[str, Any]] = None) -> VoiceInterface:
+    """Initialise and start the voice interface.
+
+    Parameters
+    ----------
+    config:
+        Optional configuration dictionary. Supported keys:
+        ``stt_script`` and ``tts_script`` for custom executable paths and
+        ``wake_words`` for the conversation manager.
+    """
+
+    cfg = config or {}
+    stt_script = Path(cfg.get("stt_script", BASE_DIR / "core" / "llm" / "stt.py"))
+    tts_script = Path(cfg.get("tts_script", BASE_DIR / "core" / "llm" / "tts.py"))
+    wake_words = cfg.get("wake_words", ["robot"])
+
+    llm = HTTPClient()
+    conv = ConversationManager(llm, wake_words=wake_words)
+    stt = SubprocessSpeechInput(stt_script)
+    tts = SubprocessTTS(tts_script)
+    output = SpeechOutput(tts)
+    iface = VoiceInterface(stt, conv, output)
+    iface.start()
+    return iface
+
+
+def start_vision(config: Optional[Dict[str, Any]] = None) -> VisionSystem:
+    """Create the vision system with ``config``."""
+    return VisionSystem(config=config)
+
+
+def create_app(config: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Create and start requested subsystems based on ``config``.
+
+    The configuration can enable subsystems via boolean flags:
+    ``voice`` and ``vision``.  Sub-dictionaries ``voice_config`` and
+    ``vision_config`` allow subsystem specific options.
+    """
+    cfg = config or {}
+    systems: Dict[str, Any] = {}
+
+    if cfg.get("voice"):
+        systems["voice"] = start_voice(cfg.get("voice_config"))
+    if cfg.get("vision"):
+        systems["vision"] = start_vision(cfg.get("vision_config"))
+    return systems

--- a/Server/core/__init__.py
+++ b/Server/core/__init__.py
@@ -1,0 +1,1 @@
+"""Core subsystems for the server."""

--- a/Server/run.py
+++ b/Server/run.py
@@ -1,25 +1,37 @@
-import os
-import sys
+from __future__ import annotations
 
-project_root = os.path.dirname(os.path.abspath(__file__))
+"""Entry point for starting server subsystems."""
 
-if project_root not in sys.path:
-    sys.path.insert(0, project_root)
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict
 
-for folder in ['core', 'lib', 'test_codes', 'network']:
-    folder_path = os.path.join(project_root, folder)
-    if folder_path not in sys.path:
-        sys.path.insert(0, folder_path)
+from .app import create_app
 
-#from hello_world import main
-#from test_led_controller import main
-#from test_led import main
-#from test_gamepad import main
-#from test_visual_perception import main  
-#from test_ws_server import main
-#from test_llm_tts import main
-#from test_voice_loop import main
-from test_voice_interface import main
 
-if __name__ == '__main__':
+def load_config(path: Path) -> Dict[str, Any]:
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Server runner")
+    parser.add_argument("-c", "--config", type=Path, help="JSON configuration file")
+    parser.add_argument("--voice", action="store_true", help="Enable voice subsystem")
+    parser.add_argument("--vision", action="store_true", help="Enable vision subsystem")
+    args = parser.parse_args()
+
+    cfg: Dict[str, Any] = {}
+    if args.config:
+        cfg.update(load_config(args.config))
+    if args.voice:
+        cfg["voice"] = True
+    if args.vision:
+        cfg["vision"] = True
+
+    create_app(cfg)
+
+
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- treat `Server/` and `Server/core/` as Python packages
- add `app` module that can start voice and vision subsystems based on config
- rewrite `run.py` to load config and bootstrap subsystems via `app`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab7d4c5564832e8f06b9cb65b2256a