### PR TITLE
Document test execution

### DIFF
--- a/Client/README.md
+++ b/Client/README.md
@@ -1,0 +1,25 @@
+# Client
+
+The client package contains the GUI and networking front‑end for FNK0050. It connects to the server over WebSockets and offers a PyQt6‑based user interface.
+
+## Running tests
+
+Install `pytest` and optional dependencies such as `websockets` and `PyQt6`. The test suite provides an in‑process WebSocket server so no external hardware is required.
+
+Run all client tests:
+
+```bash
+pytest tests/client
+```
+
+Run a single test module:
+
+```bash
+pytest tests/client/test_ws_ping.py
+```
+
+Client networking tests can read the target endpoint from the `SERVER_URI` environment variable:
+
+```bash
+SERVER_URI=ws://localhost:8765 pytest tests/client/test_ws_command.py
+```

--- a/README.md
+++ b/README.md
@@ -1,2 +1,33 @@
 # FNK0050
-FNK0050
+
+FNK0050 is a modular robotics platform split into a `Server` that controls hardware and AI capabilities and a `Client` that provides a GUI and network interface. The project also contains various tools for vision tuning and movement analysis.
+
+## Running tests
+
+The test suite is powered by [pytest](https://pytest.org). Install the optional dependencies such as `pytest`, `numpy`, `websockets`, and `PyQt6` to enable more tests. Hardware‑specific modules (gamepads, cameras, microphones, etc.) are imported with `pytest.importorskip` and will be skipped if the dependencies are missing.
+
+Run the full suite:
+
+```bash
+pytest
+```
+
+Run only client tests:
+
+```bash
+pytest tests/client
+```
+
+Run a single test module:
+
+```bash
+pytest tests/test_ws_client_async.py
+```
+
+Some client network tests honour the `SERVER_URI` environment variable to pick the WebSocket endpoint:
+
+```bash
+SERVER_URI=ws://localhost:8765 pytest tests/client/test_ws_command.py
+```
+
+See [tests/README.md](tests/README.md) for more detailed guidance on running and targeting tests.

--- a/Server/README.md
+++ b/Server/README.md
@@ -1,0 +1,22 @@
+# Server
+
+The server package implements the hardware and AI back‑end for FNK0050. It covers vision, movement, voice interaction and LLM integration, and communicates with clients via WebSockets.
+
+## Running tests
+
+Install `pytest` and any optional dependencies for the subsystems you want to exercise: `numpy` for vision, hardware drivers such as `Gamepad` or LED controllers, etc. Tests use `pytest.importorskip` so missing dependencies result in skipped tests rather than failures.
+
+Example server tests:
+
+```bash
+pytest tests/test_vision_system.py
+pytest tests/test_led.py
+```
+
+Target a specific subsystem:
+
+```bash
+pytest tests/test_voice_interface.py
+```
+
+The LLM component can be replaced by the in‑memory mock found in [`tests/mock_llm.py`](../tests/mock_llm.py).

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,50 @@
+# Tests
+
+This directory hosts the test suite for FNK0050.
+
+## Prerequisites
+
+* Python 3.10+
+* [pytest](https://pytest.org)
+* Optional libraries to enable additional tests: `numpy`, `websockets`, `PyQt6`, and hardware interfaces such as `Gamepad` or camera drivers. Tests use `pytest.importorskip` so missing optional dependencies simply cause the related tests to be skipped.
+* The LLM subsystem can be mocked using [`tests/mock_llm.py`](mock_llm.py).
+
+## Running the tests
+
+Run the entire suite from the project root:
+
+```bash
+pytest
+```
+
+Only run client tests:
+
+```bash
+pytest tests/client
+```
+
+Run a specific server test module:
+
+```bash
+pytest tests/test_vision_system.py
+```
+
+## Targeting subsystems
+
+* **Client network and GUI** – `pytest tests/client`
+* **WebSocket client** – `pytest tests/test_ws_client_async.py`
+* **Server core (vision, voice, etc.)** – run individual files under `tests/`
+
+Use `-k` to filter further, e.g. `pytest -k vision`.
+
+## Environment variables
+
+Some client networking tests honour the `SERVER_URI` variable to select the WebSocket endpoint:
+
+```bash
+SERVER_URI=ws://localhost:8765 pytest tests/client/test_ws_command.py
+```
+
+## Hardware mocks
+
+Hardware-dependent modules (gamepads, sensors, LEDs, microphones) are imported using `pytest.importorskip`. Without the actual hardware or libraries the tests will be skipped. Provide mocks or install the required libraries if you need those tests to run.


### PR DESCRIPTION
## Summary
- Add project overview and testing instructions to the root README
- Document test prerequisites and subsystem targeting under `tests/`
- Provide dedicated READMEs for `Client` and `Server` test usage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac08b22420832eb1c6c6911c57c592