### PR TITLE
Move text normalization into hearing module

### DIFF
--- a/Server/core/hearing/__init__.py
+++ b/Server/core/hearing/__init__.py
@@ -1,0 +1,6 @@
+"""Speech recognition helpers."""
+
+from .text_norm import normalize_punct
+from .stt import SpeechToText
+
+__all__ = ["normalize_punct", "SpeechToText"]

--- a/Server/core/hearing/stt.py
+++ b/Server/core/hearing/stt.py
@@ -16,10 +16,7 @@ from typing import Generator, Optional
 import sounddevice as sd
 from vosk import Model, KaldiRecognizer
 
-# Access text normalization helper from the neighbouring llm module
-BASE = Path(__file__).resolve().parent
-sys.path.append(str(BASE.parent / "llm"))
-from text_norm import normalize_punct  # type: ignore
+from .text_norm import normalize_punct
 
 # Default configuration (same as the original script)
 DEFAULT_MODEL_DIR = Path("/home/user/vosk/vosk-model-small-es-0.42")

--- a/Server/core/hearing/text_norm.py
+++ b/Server/core/hearing/text_norm.py
@@ -1,4 +1,4 @@
-# llm/text_norm.py
+# hearing/text_norm.py
 import re
 
 _Q = r"(que|qué|cual|cuál|como|cómo|donde|dónde|cuando|cuándo|por que|por qué|cuanto|cuánto|quien|quién|cuáles|cuantos|cuántos)"


### PR DESCRIPTION
## Summary
- relocate `text_norm` into the `hearing` package
- import `normalize_punct` from new location
- expose `SpeechToText` and `normalize_punct` via `core.hearing` package

## Testing
- `python -m py_compile Server/core/hearing/text_norm.py Server/core/hearing/stt.py`
- `python Server/test_codes/test_voice_loop.py` *(fails: ModuleNotFoundError: No module named 'sounddevice')*


------
https://chatgpt.com/codex/tasks/task_e_68ac2c83f238832e9c32eb7d5c0c96fb