### PR TITLE
Refactor voice STT stream

### DIFF
--- a/Server/core/VoiceInterface.py
+++ b/Server/core/VoiceInterface.py
@@ -93,16 +93,15 @@ def stt_stream():
 
     while True:
         if STT_PAUSED:
-            drained = False
-            try:
-                while True:
+            # drain any buffered phrases while paused
+            while True:
+                try:
                     item = q.get_nowait()
                     if item is None:
                         return
-                    drained = True
-            except queue.Empty:
-                pass
-            time.sleep(0.01 if drained else 0.02)
+                except queue.Empty:
+                    break
+            time.sleep(0.02)
             yield None
             continue
 


### PR DESCRIPTION
## Summary
- simplify stt_stream to drain buffered phrases while paused
- ensure ConversationManager uses generator driven STT engine

## Testing
- `python -m py_compile Server/core/VoiceInterface.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac324e3bb4832eac4bb7f792b57475