### PR TITLE
chore: clarify STT path in voice loop test

### DIFF
--- a/Server/test_codes/test_voice_loop.py
+++ b/Server/test_codes/test_voice_loop.py
@@ -14,7 +14,7 @@ import subprocess as _subprocess, sys as _sys, os as _os, argparse as _argparse
 # --- Paths (adjust if needed) ---
 _PROJECT_ROOT = _Path(__file__).resolve().parents[1]
 _LLM_TO_TTS = _PROJECT_ROOT / "core" / "llm" / "llm_to_tts.py"
-# Updated path to the speech-to-text helper in the hearing module
+# Path to the speech-to-text helper in the hearing module
 _STT_SCRIPT = _PROJECT_ROOT / "core" / "hearing" / "stt.py"
 
 def main():  # entrypoint expected by your run.py


### PR DESCRIPTION
## Summary
- document that the voice loop test uses the hearing module's `stt.py`

## Testing
- `pytest` *(fails: No module named 'network')*


------
https://chatgpt.com/codex/tasks/task_e_68ac337b63b8832e933fa3ec0b4e7924