### PR TITLE
Remove hearing package init and adjust imports

### DIFF
--- a/Server/core/hearing/__init__.py
+++ b/Server/core/hearing/__init__.py
@@ -1,6 +1,0 @@
-"""Speech recognition helpers."""
-
-from .text_norm import normalize_punct
-from .stt import SpeechToText
-
-__all__ = ["normalize_punct", "SpeechToText"]

--- a/Server/core/hearing/stt.py
+++ b/Server/core/hearing/stt.py
@@ -16,7 +16,7 @@ from typing import Generator, Optional
 import sounddevice as sd
 from vosk import Model, KaldiRecognizer
 
-from .text_norm import normalize_punct
+from core.hearing.text_norm import normalize_punct
 
 # Default configuration (same as the original script)
 DEFAULT_MODEL_DIR = Path("/home/user/vosk/vosk-model-small-es-0.42")


### PR DESCRIPTION
## Summary
- drop `Server/core/hearing/__init__.py` so hearing uses namespace packaging
- import `normalize_punct` via fully qualified module path

## Testing
- `PYTHONPATH=Server python - <<'PY'
import core.hearing.text_norm as tn
print('Normalized:', tn.normalize_punct('hola!?'))
PY`
- `PYTHONPATH=Server python Server/test_codes/test_voice_loop.py` *(fails: No module named 'sounddevice')*
- `PYTHONPATH=Server python Server/core/VoiceInterface.py` *(fails: No module named 'spidev')*


------
https://chatgpt.com/codex/tasks/task_e_68ac34deac30832e92cdd3f9091c8482