### PR TITLE
Refactor movement data helpers

### DIFF
--- a/Server/core/Control.py
+++ b/Server/core/Control.py
@@ -1,10 +1,12 @@
 import time
 import os
 import math
+from pathlib import Path
 import numpy as np
 from PID import Incremental_PID
 from movement.servo import Servo
 from movement.gait_cpg import CPG
+from movement import data
 from sensing.IMU import IMU
 from sensing.odometry import Odometry
 from Command import COMMAND as cmd
@@ -70,31 +72,13 @@ class Control:
             self.logfile = None
             self.log_enabled = False
     
-    def readFromTxt(self,filename):
-        base_path = os.path.dirname(os.path.abspath(__file__))
-        filepath = os.path.join(base_path, filename + ".txt")
-        file1 = open(filepath, "r")
-        list_row = file1.readlines()
-        list_source = []
-        for i in range(len(list_row)):
-            column_list = list_row[i].strip().split("\t")
-            list_source.append(column_list)
-        for i in range(len(list_source)):
-            for j in range(len(list_source[i])):
-                list_source[i][j] = int(list_source[i][j])
-        file1.close()
-        return list_source
+    def readFromTxt(self, filename):
+        base_path = Path(__file__).resolve().parent
+        return data.load_points(base_path / f"{filename}.txt")
 
-    def saveToTxt(self,list, filename):
-        base_path = os.path.dirname(os.path.abspath(__file__))
-        filepath = os.path.join(base_path, filename + ".txt")
-        file2 = open(filepath, 'w')
-        for i in range(len(list)):
-            for j in range(len(list[i])):
-                file2.write(str(list[i][j]))
-                file2.write('\t')
-            file2.write('\n')
-        file2.close()
+    def saveToTxt(self, list, filename):
+        base_path = Path(__file__).resolve().parent
+        data.save_points(base_path / f"{filename}.txt", list)
         
     def coordinateToAngle(self,x,y,z,l1=23,l2=55,l3=55):
         a=math.pi/2-math.atan2(z,y)

--- a/Server/core/movement/controller.py
+++ b/Server/core/movement/controller.py
@@ -18,8 +18,9 @@ import time
 from dataclasses import dataclass
 from queue import Empty, Queue
 from typing import Any, Optional, Union
+from pathlib import Path
 
-from . import gait_runner, kinematics, posture
+from . import gait_runner, kinematics, posture, data
 from .hardware import Hardware
 from .logger import MovementLogger
 
@@ -212,6 +213,16 @@ class MovementController:
                 self.run()
         else:
             gait_runner.stop(self)
+
+    # ------------------------------------------------------------------
+    def load_points_from_file(self, path: Path) -> None:
+        """Replace current leg points with coordinates from ``path``."""
+        self.point = data.load_points(path)
+
+    # ------------------------------------------------------------------
+    def save_points_to_file(self, path: Path) -> None:
+        """Persist current leg points into ``path``."""
+        data.save_points(path, self.point)
 
     # ------------------------------------------------------------------
     def _process_command(self, cmd: Command) -> None:

--- a/Server/core/movement/data.py
+++ b/Server/core/movement/data.py
@@ -10,21 +10,36 @@ from pathlib import Path
 from typing import List
 
 
-def read_from_txt(name: str) -> List[List[int]]:
-    """Read a matrix of integers from ``name``.
+def load_points(path: Path) -> List[List[int]]:
+    """Return a matrix of integers read from ``path``.
 
-    ``name`` should be provided without extension.  The file is
-    expected to contain tab separated values where each line represents
-    a row of integers.
+    The expected file format is a series of lines with tab separated
+    integers representing the *x*, *y* and *z* coordinates for each
+    leg.  Empty trailing lines are ignored.
     """
-    path = Path(__file__).with_name(f"{name}.txt")
     lines = path.read_text().splitlines()
-    return [[int(col) for col in line.split("\t")] for line in lines]
+    return [[int(col) for col in line.split("\t")] for line in lines if line]
+
+
+def save_points(path: Path, data: List[List[int]]) -> None:
+    """Persist ``data`` into ``path`` using tab separated values."""
+    with path.open("w") as fh:
+        for row in data:
+            fh.write("\t".join(str(v) for v in row) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# Backwards compatible wrappers
+
+def read_from_txt(name: str) -> List[List[int]]:
+    """Legacy wrapper around :func:`load_points`.
+
+    ``name`` should be provided without extension.  The file is looked up
+    relative to this module.
+    """
+    return load_points(Path(__file__).with_name(f"{name}.txt"))
 
 
 def save_to_txt(matrix: List[List[int]], name: str) -> None:
-    """Persist ``matrix`` into ``name`` using tab separated values."""
-    path = Path(__file__).with_name(f"{name}.txt")
-    with path.open("w") as fh:
-        for row in matrix:
-            fh.write("\t".join(str(v) for v in row) + "\n")
+    """Legacy wrapper around :func:`save_points`."""
+    save_points(Path(__file__).with_name(f"{name}.txt"), matrix)

--- a/Server/core/movement/hardware.py
+++ b/Server/core/movement/hardware.py
@@ -1,10 +1,11 @@
 """Low level hardware helpers for the quadruped robot."""
 from __future__ import annotations
 
+from pathlib import Path
 from typing import List
 
 from .kinematics import coordinate_to_angle, clamp
-from . import data
+from .data import load_points
 from .servo import Servo
 from .gait_cpg import CPG
 from ..sensing.IMU import IMU
@@ -29,7 +30,8 @@ class Hardware:
 
     # ------------------------------------------------------------------
     def load_calibration(self) -> None:
-        self.calibration_point = data.read_from_txt("point")
+        point_file = Path(__file__).resolve().parents[1] / "point.txt"
+        self.calibration_point = load_points(point_file)
         self.calibration_angle = [[0.0, 0.0, 0.0] for _ in range(4)]
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- replace Control-based txt readers with `movement.data.load_points`/`save_points`
- use `pathlib.Path` for calibration file paths
- expose file loading/saving helpers on movement controller

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'network')*


------
https://chatgpt.com/codex/tasks/task_e_68ac3af33bc8832eada867dd5d6ae812