### PR TITLE
Abstract hardware control

### DIFF
--- a/Server/core/MovementControl.py
+++ b/Server/core/MovementControl.py
@@ -20,9 +20,9 @@ from movement.logger import MovementLogger
 class MovementControl:
     """High-level façade queuing movement commands."""
 
-    def __init__(self) -> None:
-        hardware = Hardware()
-        logger = MovementLogger()
+    def __init__(self, hardware: Hardware | None = None, logger: MovementLogger | None = None) -> None:
+        hardware = hardware or Hardware()
+        logger = logger or MovementLogger()
         self.controller = MovementController(hardware, hardware.cpg, logger)
 
     def walk(self, vx: float, vy: float, omega: float) -> None:

--- a/Server/core/movement/controller.py
+++ b/Server/core/movement/controller.py
@@ -124,8 +124,7 @@ class MovementController:
         if self.checkPoint():
             try:
                 self.update_angles_from_points()
-                self.hardware.apply_calibration_to_angles(self.angle)
-                self.hardware.send_angles_to_servos(self.angle)
+                self.hardware.apply_angles(self.angle)
                 self.logger.log_current_state(self)
             except Exception as e:
                 print("Exception during run():", e)
@@ -213,6 +212,7 @@ class MovementController:
                 self.run()
         else:
             gait_runner.stop(self)
+        self.hardware.relax()
 
     # ------------------------------------------------------------------
     def load_points_from_file(self, path: Path) -> None:

--- a/Server/core/movement/hardware.py
+++ b/Server/core/movement/hardware.py
@@ -1,8 +1,24 @@
-"""Low level hardware helpers for the quadruped robot."""
+"""Hardware abstraction for robot movement.
+
+This module centralises access to low level devices such as the PCA9685
+servo controller, IMU and odometry.  It also encapsulates the mapping
+between logical leg joints and physical servo channels as well as the
+calibration offsets for each joint.
+
+The :class:`Hardware` class exposes two public methods used by the higher
+level movement controller:
+
+``apply_angles``
+    Apply a list of joint angles to the servos taking calibration into
+    account.
+
+``relax``
+    Disable all servo outputs, allowing the robot to relax.
+"""
 from __future__ import annotations
 
 from pathlib import Path
-from typing import List
+from typing import Iterable, List
 
 from .kinematics import coordinate_to_angle, clamp
 from .data import load_points
@@ -15,6 +31,14 @@ from ..PID import Incremental_PID
 
 class Hardware:
     """Bundle of devices used by the movement controller."""
+
+    #: Mapping from leg index to PCA9685 channels (hip, thigh, knee)
+    SERVO_MAP = (
+        (4, 3, 2),   # Front-left
+        (7, 6, 5),   # Rear-left
+        (8, 9, 10),  # Rear-right
+        (11, 12, 13) # Front-right
+    )
 
     def __init__(self) -> None:
         self.setup_hardware()
@@ -36,6 +60,7 @@ class Hardware:
 
     # ------------------------------------------------------------------
     def calibration(self, point: List[List[float]], angle: List[List[float]]) -> None:
+        """Compute calibration offsets from reference points."""
         for i in range(4):
             self.calibration_angle[i][0], self.calibration_angle[i][1], self.calibration_angle[i][2] = coordinate_to_angle(
                 self.calibration_point[i][0], self.calibration_point[i][1], self.calibration_point[i][2]
@@ -50,7 +75,7 @@ class Hardware:
             self.calibration_angle[i][2] -= angle[i][2]
 
     # ------------------------------------------------------------------
-    def apply_calibration_to_angles(self, angle: List[List[float]]) -> None:
+    def _apply_calibration_to_angles(self, angle: List[List[float]]) -> None:
         for i in range(2):
             # Left legs
             angle[i][0] = clamp(angle[i][0] + self.calibration_angle[i][0], 0, 180)
@@ -63,12 +88,27 @@ class Hardware:
             angle[i + 2][2] = clamp(180 - (angle[i + 2][2] + self.calibration_angle[i + 2][2]), 0, 180)
 
     # ------------------------------------------------------------------
-    def send_angles_to_servos(self, angle: List[List[float]]) -> None:
-        for i in range(2):
-            self.servo.setServoAngle(4 + i * 3, angle[i][0])
-            self.servo.setServoAngle(3 + i * 3, angle[i][1])
-            self.servo.setServoAngle(2 + i * 3, angle[i][2])
+    def _send_angles_to_servos(self, angle: Iterable[Iterable[float]]) -> None:
+        for channels, leg_angle in zip(self.SERVO_MAP, angle):
+            for ch, ang in zip(channels, leg_angle):
+                self.servo.set_servo_angle(ch, ang)
 
-            self.servo.setServoAngle(8 + i * 3, angle[i + 2][0])
-            self.servo.setServoAngle(9 + i * 3, angle[i + 2][1])
-            self.servo.setServoAngle(10 + i * 3, angle[i + 2][2])
+    # ------------------------------------------------------------------
+    def apply_angles(self, angle: List[List[float]]) -> None:
+        """Apply joint angles to the servos.
+
+        The provided ``angle`` matrix is modified in place after applying the
+        calibration offsets and finally dispatched to the PCA9685 driver.
+        """
+        self._apply_calibration_to_angles(angle)
+        self._send_angles_to_servos(angle)
+
+    # ------------------------------------------------------------------
+    def relax(self) -> None:
+        """Disable all servo outputs allowing the robot to relax."""
+        pwm = self.servo.pwm
+        for ch in range(16):
+            if hasattr(pwm, "set_pwm"):
+                pwm.set_pwm(ch, 0, 0)
+            elif hasattr(pwm, "setPWM"):
+                pwm.setPWM(ch, 0, 0)


### PR DESCRIPTION
## Summary
- centralize servo mapping and calibration in hardware layer with `apply_angles` and `relax`
- update controllers to delegate angle application and support hardware injection
- replace direct servo calls with hardware abstraction

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'network')*


------
https://chatgpt.com/codex/tasks/task_e_68ac3c85ffb8832eaf3bd72b0852e418