### PR TITLE
Enable hardware dependency injection for movement controller

### DIFF
--- a/Server/core/MovementControl.py
+++ b/Server/core/MovementControl.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from movement.controller import (
     AttitudeCmd,
-    Command,
     HeightCmd,
     MovementController,
     RelaxCmd,
@@ -18,10 +17,20 @@ from movement.logger import MovementLogger
 class MovementControl:
     """High-level façade queuing movement commands."""
 
-    def __init__(self, hardware: Hardware | None = None, logger: MovementLogger | None = None) -> None:
-        hardware = hardware or Hardware()
-        logger = logger or MovementLogger()
-        self.controller = MovementController(hardware, hardware.cpg, logger)
+    def __init__(
+        self,
+        hardware: Hardware | None = None,
+        logger: MovementLogger | None = None,
+        *,
+        imu: object | None = None,
+        odom: object | None = None,
+    ) -> None:
+        self.controller = MovementController(
+            hardware=hardware,
+            logger=logger,
+            imu=imu,
+            odom=odom,
+        )
 
     def walk(self, vx: float, vy: float, omega: float) -> None:
         """\brief Request continuous walking velocity.

--- a/Server/core/movement/controller.py
+++ b/Server/core/movement/controller.py
@@ -77,11 +77,36 @@ class MovementController:
     MAX_SPEED_LIMIT = 200
     MIN_SPEED_LIMIT = 20
 
-    def __init__(self, hardware: Hardware, gait: Any, logger: MovementLogger, config: Optional[dict] = None) -> None:
-        self.hardware = hardware
-        self.gait = GaitRunner(gait)
+    def __init__(
+        self,
+        hardware: Optional[Hardware] = None,
+        gait: Optional[Any] = None,
+        logger: Optional[MovementLogger] = None,
+        *,
+        imu: Optional[Any] = None,
+        odom: Optional[Any] = None,
+        config: Optional[dict] = None,
+    ) -> None:
+        """Create a new movement controller.
+
+        Parameters
+        ----------
+        hardware:
+            Optional pre-configured :class:`Hardware` bundle.  If omitted a
+            new one will be created.
+        gait:
+            Optional CPG or gait runner to drive the legs.  Defaults to the
+            CPG embedded in ``hardware``.
+        logger:
+            Optional movement logger instance.
+        imu, odom:
+            Optional IMU and odometry instances forwarded to
+            :class:`Hardware` when it needs to construct its own bundle.
+        """
+        self.hardware = hardware or Hardware(imu=imu, odom=odom)
+        self.gait = GaitRunner(gait or self.hardware.cpg)
         self.cpg = self.gait.cpg
-        self.logger = logger
+        self.logger = logger or MovementLogger()
         self.config = config or {}
         self.state = "idle"
         self.queue: Queue[Command] = Queue()

--- a/Server/core/movement/hardware.py
+++ b/Server/core/movement/hardware.py
@@ -18,7 +18,7 @@ level movement controller:
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Iterable, List
+from typing import Iterable, List, Optional
 
 from .kinematics import coordinate_to_angle, clamp
 from .data import load_points
@@ -40,16 +40,28 @@ class Hardware:
         (11, 12, 13) # Front-right
     )
 
-    def __init__(self) -> None:
-        self.setup_hardware()
+    def __init__(self, *, imu: Optional[IMU] = None, odom: Optional[Odometry] = None) -> None:
+        """Create a new hardware bundle.
+
+        Parameters
+        ----------
+        imu:
+            Optional IMU instance.  If ``None`` a default :class:`IMU` will be
+            constructed.
+        odom:
+            Optional odometry instance.  If ``None`` a default
+            :class:`Odometry` will be constructed.
+        """
+        self.setup_hardware(imu=imu, odom=odom)
         self.load_calibration()
 
     # ------------------------------------------------------------------
-    def setup_hardware(self) -> None:
-        self.imu = IMU()
+    def setup_hardware(self, *, imu: Optional[IMU] = None, odom: Optional[Odometry] = None) -> None:
+        """Initialise the individual hardware components."""
+        self.imu = imu or IMU()
         self.servo = Servo()
         self.pid = Incremental_PID(0.5, 0.0, 0.0025)
-        self.odom = Odometry(stride_gain=0.55)
+        self.odom = odom or Odometry(stride_gain=0.55)
         self.cpg = CPG("walk")
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Allow Hardware to accept optional IMU and odometry instances
- Let MovementController create hardware and logger only when not supplied
- Inject mocked hardware into MovementControl for easier unit testing

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'network')*

------
https://chatgpt.com/codex/tasks/task_e_68ac42da4044832e99a4c1f8515d6191