### PR TITLE
Switch movement hardware module to absolute imports

### DIFF
--- a/Server/core/movement/hardware.py
+++ b/Server/core/movement/hardware.py
@@ -24,9 +24,9 @@ from .kinematics import coordinate_to_angle, clamp
 from .data import load_points
 from .servo import Servo
 from .gait_cpg import CPG
-from ..sensing.IMU import IMU
-from ..sensing.odometry import Odometry
-from ..PID import Incremental_PID
+from sensing.IMU import IMU
+from sensing.odometry import Odometry
+from PID import Incremental_PID
 
 
 class Hardware:


### PR DESCRIPTION
## Summary
- replace relative movement hardware imports with absolute paths so that IMU, odometry, and PID modules resolve using run.py's sys.path

## Testing
- `python Server/run.py` *(fails: No module named 'spidev')*


------
https://chatgpt.com/codex/tasks/task_e_68ac473c0c20832eb576ec62bc413f2a