### PR TITLE
Allow adjusting movement speed

### DIFF
--- a/Server/core/MovementControl.py
+++ b/Server/core/MovementControl.py
@@ -75,6 +75,20 @@ class MovementControl:
         """\brief Relax the robot servos."""
         self.controller.queue.put(RelaxCmd())
 
+    def set_speed(self, speed: int) -> None:
+        """\brief Set the controller speed.
+
+        Exposes :meth:`MovementController.set_speed` so that callers (and
+        tests) can adjust the execution speed before issuing commands such as
+        :class:`StepCmd`.
+
+        Parameters
+        ----------
+        speed:
+            Target speed value to apply.
+        """
+        self.controller.set_speed(speed)
+
     def tick(self, dt: float) -> None:
         """Process pending commands.
 

--- a/Server/core/movement/controller.py
+++ b/Server/core/movement/controller.py
@@ -119,7 +119,10 @@ class MovementController:
 
     # ------------------------------------------------------------------
     def setup_state(self) -> None:
-        self.speed = self.MIN_SPEED_LIMIT
+        # Start with a speed above the minimum limit so the controller moves
+        # at a sensible pace by default. Tests can still adjust this value via
+        # :meth:`set_speed` exposed on :class:`MovementControl`.
+        self.speed = 120
         self.height = 99
         self.step_height = 10
         self.step_length = 15
@@ -132,6 +135,20 @@ class MovementController:
         self._stride_dir_x = 1
         self._stride_dir_z = 0
         self.stop_requested = False
+
+    # ------------------------------------------------------------------
+    def set_speed(self, speed: int) -> None:
+        """Update the controller speed.
+
+        Parameters
+        ----------
+        speed:
+            New target speed value. Values outside the permitted range are
+            clamped to remain within :data:`MIN_SPEED_LIMIT` and
+            :data:`MAX_SPEED_LIMIT`.
+        """
+        self.speed = speed
+        self.clamp_speed()
 
     # ------------------------------------------------------------------
     def set_leg_position(self, leg: int, x: float, y: float, z: float) -> None:


### PR DESCRIPTION
## Summary
- Start movement controller at higher default speed
- Add `set_speed` to MovementController with clamping logic
- Expose `set_speed` in MovementControl for test configuration

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'network')*


------
https://chatgpt.com/codex/tasks/task_e_68ac6cf75d80832e8e1a5d094ffcec4a