### PR TITLE
Handle stop-request in movement controller

### DIFF
--- a/Server/core/movement/controller.py
+++ b/Server/core/movement/controller.py
@@ -165,6 +165,9 @@ class MovementController:
 
     # ------------------------------------------------------------------
     def run(self) -> None:
+        if self.stop_requested:
+            self.hardware.relax()
+            return
         if self.checkPoint():
             try:
                 self.update_angles_from_points()
@@ -250,7 +253,6 @@ class MovementController:
                 self.run()
         else:
             self.gait.stop(self)
-        self.hardware.relax()
 
     # ------------------------------------------------------------------
     def load_points_from_file(self, path: Path) -> None:


### PR DESCRIPTION
## Summary
- Add early stop handling in `MovementController.run` to relax hardware when stop is requested
- Remove direct hardware relax call from `MovementController.relax`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'network')*

------
https://chatgpt.com/codex/tasks/task_e_68ac6dd4706c832e9144e596d0aca5d5