### PR TITLE
Avoid stop after gamepad relax command

### DIFF
--- a/Server/test_codes/test_gamepad.py
+++ b/Server/test_codes/test_gamepad.py
@@ -37,6 +37,7 @@ def polling_loop(gamepad, controller):
                     controller.step('left', 1.0)
             elif gamepad.isPressed('B'):
                 controller.relax()
+                continue
             else:
                 controller.stop()
 


### PR DESCRIPTION
## Summary
- Skip enqueuing a stop command when the gamepad's B button requests a relax state

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68ac72b8f448832e8c82028b7f6b1d6c