### PR TITLE
Add optional pose flag to relax command

### DIFF
--- a/Server/core/movement/controller.py
+++ b/Server/core/movement/controller.py
@@ -63,7 +63,7 @@ class StopCmd:
 
 @dataclass
 class RelaxCmd:
-    pass
+    to_pose: bool = True
 
 
 Command = Union[WalkCmd, StepCmd, TurnCmd, HeightCmd, AttitudeCmd, StopCmd, RelaxCmd]
@@ -320,7 +320,7 @@ class MovementController:
             self._turn_dir = 0
             self._active_cmd = None
         elif isinstance(cmd, RelaxCmd):
-            self.relax()
+            self.relax(flag=cmd.to_pose)
             self.stop_requested = True
             self._active_cmd = None
 


### PR DESCRIPTION
## Summary
- let RelaxCmd specify whether to relax to default pose
- handle RelaxCmd in controller with pose flag

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'network')*

------
https://chatgpt.com/codex/tasks/task_e_68ac76329088832e8c5cc1dc0531c486