### PR TITLE
Add greeting and relax actions to gamepad polling loop

### DIFF
--- a/Server/test_codes/test_gamepad.py
+++ b/Server/test_codes/test_gamepad.py
@@ -35,6 +35,9 @@ def polling_loop(gamepad, controller):
                     controller.step('right', 1.0)
                 elif x1 < -DEADZONE:
                     controller.step('left', 1.0)
+            elif gamepad.isPressed('A'):
+                controller.greet()
+                continue
             elif gamepad.isPressed('B'):
                 controller.relax()
                 continue


### PR DESCRIPTION
## Summary
- Add handling for A button to trigger `controller.greet()`
- Keep B button branch, calling `controller.relax()` and skipping stop commands

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'network')*

------
https://chatgpt.com/codex/tasks/task_e_68ac77d59a40832e884d0d860926a76b