### PR TITLE
Explicitly request relaxed pose before torque release

### DIFF
--- a/Server/core/MovementControl.py
+++ b/Server/core/MovementControl.py
@@ -73,8 +73,8 @@ class MovementControl:
         self.controller.queue.put(StopCmd())
 
     def relax(self) -> None:
-        """\brief Relax the robot servos."""
-        self.controller.queue.put(RelaxCmd())
+        """\brief Move to the predefined relaxed pose before releasing torque."""
+        self.controller.queue.put(RelaxCmd(to_pose=True))
 
     def greet(self) -> None:
         """\brief Perform a greeting action."""


### PR DESCRIPTION
## Summary
- Explicitly enqueue `RelaxCmd` with `to_pose=True` to ensure robot moves to predefined relaxed posture before releasing torque
- Document relaxing behavior to clarify movement to relaxed pose

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'network'; No module named 'gui'; No module named 'numpy'; No module named 'spidev'; No module named 'picamera2')*

------
https://chatgpt.com/codex/tasks/task_e_68ac7c5f0350832eb6c8366d0efecba1