### PR TITLE
Add gesture engine and edge-triggered greeting

### DIFF
--- a/Server/core/MovementControl.py
+++ b/Server/core/MovementControl.py
@@ -6,6 +6,7 @@ from movement.controller import (
     MovementController,
     RelaxCmd,
     GreetCmd,
+    GestureCmd,
     StepCmd,
     StopCmd,
     TurnCmd,
@@ -77,8 +78,12 @@ class MovementControl:
         self.controller.queue.put(RelaxCmd(to_pose=True))
 
     def greet(self) -> None:
-        """\brief Perform a greeting action."""
-        self.controller.queue.put(GreetCmd())
+        """\brief Play the default greeting gesture."""
+        self.controller.queue.put(GestureCmd(name="greet"))
+
+    def gesture(self, name: str) -> None:
+        """\brief Play any named gesture via the controller's gesture engine."""
+        self.controller.queue.put(GestureCmd(name=name))
 
     def set_speed(self, speed: int) -> None:
         """\brief Set the controller speed.

--- a/Server/test_codes/test_gamepad.py
+++ b/Server/test_codes/test_gamepad.py
@@ -15,6 +15,7 @@ def polling_loop(gamepad, controller):
     """Poll gamepad and enqueue movement commands."""
     DEADZONE = 0.2
     prev_B = False
+    prev_A = False
     while True:
         try:
             x0 = gamepad.axis(0)
@@ -36,9 +37,11 @@ def polling_loop(gamepad, controller):
                     controller.step('right', 1.0)
                 elif x1 < -DEADZONE:
                     controller.step('left', 1.0)
-            elif gamepad.isPressed('A'):
-                controller.greet()
-                continue  # Skip queuing stop so greeting plays fully
+            # Edge-trigger A like B (avoid enqueuing every frame)
+            elif (gamepad.isPressed('A') and not prev_A):
+                controller.greet()  # or controller.gesture("greet")
+                prev_A = True
+                continue
             else:
                 b_pressed = gamepad.isPressed('B')
                 if b_pressed and not prev_B:
@@ -50,6 +53,8 @@ def polling_loop(gamepad, controller):
                     prev_B = False
                 # If B is held, do nothing to avoid repeated RelaxCmd
 
+            prev_B = gamepad.isPressed('B')
+            prev_A = gamepad.isPressed('A')
             time.sleep(0.1)
         except Exception as e:
             print("Polling error:", e)


### PR DESCRIPTION
## Summary
- add generic gesture engine and GestureCmd for non-blocking animations
- expose gesture playback in MovementControl and map greet() to it
- trigger greeting on button A edge and track A/B states in test gamepad

## Testing
- `python -m py_compile Server/core/movement/controller.py Server/core/MovementControl.py Server/test_codes/test_gamepad.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'network')*


------
https://chatgpt.com/codex/tasks/task_e_68ac37e78fc0832e9f4a15fe194fbb45