### PR TITLE
Ensure single-shot button actions in gamepad test

### DIFF
--- a/Server/test_codes/test_gamepad.py
+++ b/Server/test_codes/test_gamepad.py
@@ -7,6 +7,8 @@ from Action import Action
 def polling_loop(gamepad, action):
 
     DEADZONE = 0.2
+    prev_A = False
+    prev_B = False
 
     while(True):
         try:
@@ -33,14 +35,17 @@ def polling_loop(gamepad, action):
                 elif x1 < -DEADZONE:
                     action.state = 'step_left'
 
-            elif gamepad.isPressed('A'):
+            elif gamepad.isPressed('A') and not prev_A:
                 action.state = 'greeting'
 
-            elif gamepad.isPressed('B'):
+            elif gamepad.isPressed('B') and not prev_B:
                 action.state = 'relax'
 
             else:
                 action.state = 'idle'
+
+            prev_A = gamepad.isPressed('A')
+            prev_B = gamepad.isPressed('B')
 
             time.sleep(0.1)
 


### PR DESCRIPTION
## Summary
- trigger greeting or relax only once when gamepad buttons are pressed
- track previous button states to ignore held buttons

## Testing
- `python -m py_compile Server/test_codes/test_gamepad.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'network')*
- `python - <<'PY'
prev_A = False
prev_B = False
action_states = []
sequence_A = [False, True, True, False]
sequence_B = [False, False, False, False]
for A, B in zip(sequence_A, sequence_B):
    if A and not prev_A:
        state = 'greeting'
    elif B and not prev_B:
        state = 'relax'
    else:
        state = 'idle'
    action_states.append(state)
    prev_A = A
    prev_B = B
print(action_states)
PY`
- `python - <<'PY'
prev_A = False
prev_B = False
action_states = []
sequence_A = [False, False, False, False]
sequence_B = [False, True, True, False]
for A, B in zip(sequence_A, sequence_B):
    if A and not prev_A:
        state = 'greeting'
    elif B and not prev_B:
        state = 'relax'
    else:
        state = 'idle'
    action_states.append(state)
    prev_A = A
    prev_B = B
print(action_states)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68ac9fcd76d0832eb3dac116119a724f