### PR TITLE
Refactor gesture test utilities to new movement controller

### DIFF
--- a/Server/test_codes/hello_world.py
+++ b/Server/test_codes/hello_world.py
@@ -1,11 +1,30 @@
-from Action import Action
+"""Simple greeting test using the high level controller.
+
+This script demonstrates the new non-blocking gesture system. Gestures are
+started instantly and then progressed by repeatedly calling ``update`` with a
+time delta. They can be cancelled at any time via :meth:`relax`.
+"""
+
+import time
+
+from movement.controller import Controller
 
 def main():
     print("Hello!! (●'◡'●)")
 
-    action = Action()
+    controller = Controller()
 
-    action.hello()
+    # Gestures are tick-driven and do not block. Start the built-in greeting
+    # gesture and then advance it in a loop, simulating a main control loop.
+    controller.gestures.start("greet")
+
+    for _ in range(20):
+        controller.update(0.1)
+        time.sleep(0.1)
+
+    # ``relax`` cancels any active gesture and returns the robot to a safe
+    # resting state.
+    controller.relax(True)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- Switch test utilities to construct the new movement `Controller` instead of deprecated `Action`
- Update greetings to use `controller.gestures.start("greet")` and document tick-driven, non-blocking gestures
- Drive gesture progression with `update()` and demonstrate cancellation via `relax()`

## Testing
- `python -m py_compile Server/test_codes/hello_world.py Server/test_codes/test_gamepad.py`


------
https://chatgpt.com/codex/tasks/task_e_68aca6c5d59c832e87b2b6eb4e73f38c