### PR TITLE
Allow configurable gesture durations

### DIFF
--- a/Server/core/movement/test_gestures_speed.py
+++ b/Server/core/movement/test_gestures_speed.py
@@ -1,0 +1,41 @@
+import os
+import sys
+import unittest
+
+# Ensure the core package is on the Python path
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from movement.gestures import Gestures
+
+
+class _StubController:
+    def __init__(self):
+        self.point = [
+            [0, 0, 0],
+            [0, 0, 0],
+            [0, 0, 0],
+            [0, 0, 0],
+        ]
+        self._locomotion_enabled = True
+
+    def stop(self):
+        pass
+
+
+class GestureSpeedTest(unittest.TestCase):
+    def setUp(self):
+        self.controller = _StubController()
+        self.gestures = Gestures(self.controller)
+
+    def test_speed_scalar_scales_durations(self):
+        self.gestures.start("greet", speed=2.0)
+        self.assertAlmostEqual(self.gestures._durations[0], 0.3)
+
+    def test_duration_override(self):
+        custom = [1.0, 1.0, 1.0, 1.0]
+        self.gestures.start("greet", durations=custom)
+        self.assertEqual(self.gestures._durations, custom)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- store default gesture phase durations in a configuration mapping
- allow `Gestures.start` to scale or override phase durations and update interpolation logic
- document default timings and provide unit tests for duration tuning

## Testing
- `pytest Server/core/movement -q`

------
https://chatgpt.com/codex/tasks/task_e_68acb20b0da4832e888171760be77eb9