### PR TITLE
Document gesture API and usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
 # FNK0050
-FNK0050
+
+Utilities and experiments for controlling a small quadruped robot.
+
+## Gesture support
+
+The movement server exposes a :class:`Gestures` helper for scripted leg
+motions.  Gestures consist of sequences of absolute foot coordinates and are
+advanced in a non-blocking manner by repeatedly calling ``update(dt)`` within
+the main control loop.
+
+To add a custom gesture:
+
+```python
+from Server.core.movement.gestures import Gestures
+
+g = Gestures(controller)
+g.add_gesture(
+    "wave",
+    [
+        [[55, 78, 0], [55, 78, 0], [55, 78, 0], [55, 78, 0]],
+        [[55, 78, 0], [55, 78, 0], [55, 78, 0], [80, 23, 0]],
+    ],
+    [0.5, 0.5],
+)
+g.start("wave")
+```


### PR DESCRIPTION
## Summary
- expand `gestures.py` module docs with controller interface, absolute coordinate semantics, and non-blocking behavior
- add usage example for registering custom gesture sequences
- mention gesture support and non-blocking absolute coordinates in README

## Testing
- `pytest Server/core/movement -q`


------
https://chatgpt.com/codex/tasks/task_e_68acb3c62028832eb40dccaa633604b2