### PR TITLE
Handle gamepad disconnects in gamepad test

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,12 @@ g.add_gesture(
 )
 g.start("wave")
 ```
+
+## Gamepad testing
+
+The script `Server/test_codes/test_gamepad.py` demonstrates polling an
+Xbox360-style controller. If the gamepad disconnects or another error occurs,
+the polling loop clears internal button-state flags (`prev_A` and `prev_B`) and
+the main loop waits briefly before attempting to reconnect. The connection
+status of a controller can be queried with `Gamepad.is_connected()` to aid
+testing when no physical gamepad is present.

--- a/Server/lib/Gamepad.py
+++ b/Server/lib/Gamepad.py
@@ -23,6 +23,20 @@ def available(joystickNumber = 0):
     joystickPath = '/dev/input/js' + str(joystickNumber)
     return os.path.exists(joystickPath)
 
+
+def is_connected(gamepad):
+    """Utility function to query the connection status of a gamepad instance.
+
+    Returns True if the gamepad reports an active connection, otherwise
+    False. If the provided object does not have the expected interface,
+    False is returned.
+    """
+    try:
+        return gamepad.isConnected()
+    except AttributeError:
+        return False
+
+
 class Gamepad:
     EVENT_CODE_BUTTON = 0x01
     EVENT_CODE_AXIS = 0x02

--- a/Server/test_codes/test_gamepad.py
+++ b/Server/test_codes/test_gamepad.py
@@ -5,14 +5,20 @@ import threading
 from movement.controller import Controller
 
 
-def polling_loop(gamepad, controller):
+def polling_loop(gamepad, controller, state):
+    """Continuously poll the gamepad and drive the controller.
+
+    Any exception (such as a disconnect) resets the previous button states so
+    that subsequent connection attempts start cleanly.
+    """
 
     DEADZONE = 0.2
-    prev_A = False
-    prev_B = False
 
-    while(True):
+    while True:
         try:
+            if not Gamepad.is_connected(gamepad):
+                raise IOError("Gamepad disconnected")
+
             x0 = gamepad.axis(0)
             y0 = gamepad.axis(1)
             x1 = gamepad.axis(3)
@@ -40,17 +46,17 @@ def polling_loop(gamepad, controller):
                 elif x1 < -DEADZONE:
                     controller.stepLeft()
 
-            elif gamepad.isPressed('A') and not prev_A:
+            elif gamepad.isPressed('A') and not state['prev_A']:
                 controller.gestures.start("greet")
 
-            elif gamepad.isPressed('B') and not prev_B:
+            elif gamepad.isPressed('B') and not state['prev_B']:
                 controller.relax(True)
 
             else:
                 controller.stop()
 
-            prev_A = gamepad.isPressed('A')
-            prev_B = gamepad.isPressed('B')
+            state['prev_A'] = gamepad.isPressed('A')
+            state['prev_B'] = gamepad.isPressed('B')
 
             # Gestures run asynchronously; ``update`` advances them each tick.
             controller.update(0.1)
@@ -58,34 +64,55 @@ def polling_loop(gamepad, controller):
 
         except Exception as e:
             print("Polling error:", e)
+            state['prev_A'] = False
+            state['prev_B'] = False
             break
 
 
 def main():
-    
+
     print("Test Gamepad")
     test_mode = False
+    state = {'prev_A': False, 'prev_B': False}
 
-    try:
-        gamepad = Gamepad.Xbox360()
-        gamepad.startBackgroundUpdates()
+    while True:
+        gamepad = None
+        try:
+            gamepad = Gamepad.Xbox360()
+            gamepad.startBackgroundUpdates()
 
-        controller = Controller()
+            controller = Controller()
 
-        if not test_mode:
-            thread = threading.Thread(target=polling_loop, args=(gamepad, controller))
-            thread.daemon = True  # will be closed with main script
-            thread.start()
+            if not test_mode:
+                thread = threading.Thread(target=polling_loop, args=(gamepad, controller, state))
+                thread.daemon = True  # will be closed with main script
+                thread.start()
+                while thread.is_alive() and Gamepad.is_connected(gamepad):
+                    time.sleep(0.5)
+            else:
+                while Gamepad.is_connected(gamepad):
+                    eventType, name, value = gamepad.getNextEvent()
+                    print(f"Evento: {eventType:<6}  |  {name:<12}  |  Valor: {value}")
 
-        print("Connected")
-  
-    except Exception as e:
-        print("Can't link with:", e)
-        return
-    
-    while (test_mode):
-        eventType, name, value = gamepad.getNextEvent()
-        print(f"Evento: {eventType:<6}  |  {name:<12}  |  Valor: {value}")
+            print("Disconnected")
+
+        except KeyboardInterrupt:
+            break
+        except Exception as e:
+            print("Can't link with:", e)
+        finally:
+            state['prev_A'] = False
+            state['prev_B'] = False
+            if gamepad is not None:
+                try:
+                    gamepad.stopBackgroundUpdates()
+                except Exception:
+                    pass
+            if test_mode:
+                break
+            print("Reconnecting in 1 second...")
+            time.sleep(1)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- Reset prev_A and prev_B when the polling loop encounters a disconnect
- Add reconnection logic and reset flags in test_gamepad
- Expose Gamepad.is_connected utility and document connection behaviour

## Testing
- `python -m py_compile Server/lib/Gamepad.py Server/test_codes/test_gamepad.py`
- `pip install numpy` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68acb56b2428832ea9a5c1c307c5060f