### PR TITLE
Integrate gesture engine into movement controller

### DIFF
--- a/Server/core/movement/controller.py
+++ b/Server/core/movement/controller.py
@@ -90,12 +90,10 @@ class Controller(Control):
     def update_legs_from_cpg(self, dt: float) -> None:  # type: ignore[override]
         """Update leg positions and handle gestures before CPG updates."""
         if self.gestures.active:
-            finished = self.gestures.update(dt)
-            if finished:
-                self._locomotion_enabled = True
+            self.gestures.update(dt)
             return
 
-        if not self._locomotion_enabled or not self._gait_enabled:
+        if not (self._locomotion_enabled and self._gait_enabled):
             return
 
         super().update_legs_from_cpg(dt)

--- a/Server/test_codes/test_gamepad.py
+++ b/Server/test_codes/test_gamepad.py
@@ -47,12 +47,12 @@ def polling_loop(gamepad, controller, state):
                     controller.stepLeft()
 
             elif gamepad.isPressed('A') and not state['prev_A']:
-                controller.gestures.start("greet")
+                controller.greet()
 
             elif gamepad.isPressed('B') and not state['prev_B']:
                 controller.relax(True)
 
-            else:
+            elif not controller.gestures.active:
                 controller.stop()
 
             state['prev_A'] = gamepad.isPressed('A')


### PR DESCRIPTION
## Summary
- Use a dedicated Gestures helper to drive scripted leg motions
- Prevent locomotion while gestures are active and cancel them during relax/stop routines
- Trigger greeting from the gamepad on button A edge and avoid canceling mid-gesture

## Testing
- `pytest Server/core/movement/test_gestures_speed.py Server/core/movement/test_controller_cancel.py Server/core/movement/test_gestures_unknown.py -q`
- `pytest -q` *(fails: No module named 'network'; No module named 'Gamepad'; No module named 'spidev'; No module named 'picamera2')*

------
https://chatgpt.com/codex/tasks/task_e_68ad6ce0aec8832eac072918572d0c16