### PR TITLE
Add controller-based hello wave gesture

### DIFF
--- a/Server/core/movement/controller.py
+++ b/Server/core/movement/controller.py
@@ -24,7 +24,7 @@ from . import kinematics, posture, data
 from .gait_runner import GaitRunner
 from .hardware import Hardware
 from .logger import MovementLogger
-from .gestures import GesturePlayer, build_hello_wave_sequence
+from .gestures import GesturePlayer, build_hello_wave_sequence_from
 
 
 @dataclass
@@ -295,14 +295,14 @@ class MovementController:
     # ------------------------------------------------------------------
     # ------------------------------------------------------------------
     def _play_gesture(self, name: str) -> None:
-        mapping = {"greet": build_hello_wave_sequence}
+        mapping = {"greet": build_hello_wave_sequence_from}
         builder = mapping.get(name)
         if not builder:
             return
         self.stop_requested = False
         self.torque_off = False
         self._gait_enabled = False
-        self.gestures.play(builder(), blocking=False)
+        self.gestures.play(builder(self), blocking=False)
 
     # ------------------------------------------------------------------
     def _process_command(self, cmd: Command) -> None:


### PR DESCRIPTION
## Summary
- add `build_hello_wave_sequence_from` to derive gesture from controller pose
- deprecate fixed-base `build_hello_wave_sequence`
- wire MovementController greet gesture to new builder

## Testing
- `pytest tests/test_gestures.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'network')*


------
https://chatgpt.com/codex/tasks/task_e_68ad88cd1cf0832eb580c331bf1d5523