### PR TITLE
Support JSON gesture sequences with dynamic loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
 # FNK0050
+
 FNK0050
+
+## Gesture JSON format
+
+Custom movement gestures can be defined as JSON files placed under
+`Server/core/movement/gestures/`. The expected schema is::
+
+```
+{
+  "name": "wave",            // optional, defaults to file name
+  "loop": false,              // optional
+  "frames": [
+    {
+      "t": 0,                 // milliseconds from start
+      "legs": [[x, y, z], [x, y, z], [x, y, z], [x, y, z]],
+      "overrides": {"11": 92} // optional servo channel overrides
+    },
+    ...
+  ]
+}
+```
+
+Each frame specifies absolute foot positions for all four legs.  Optional
+`overrides` can directly command individual servo channels for one-off
+effects.


### PR DESCRIPTION
## Summary
- Add `load_sequence_json` to build gesture sequences from JSON files
- Enable MovementController to lazily load and cache gestures from `gestures/*.json`
- Document custom gesture JSON schema in project README

## Testing
- `pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad8ebcbb44832eaf51bcd353385044