### PR TITLE
Add dedicated GreetCmd command

### DIFF
--- a/Server/core/MovementControl.py
+++ b/Server/core/MovementControl.py
@@ -91,7 +91,7 @@ class MovementControl:
 
     def greet(self) -> None:
         """\brief Play the default greeting gesture."""
-        self.controller.queue.put(GestureCmd(name="greet"))
+        self.controller.queue.put(GreetCmd())
 
     def gesture(self, name: str) -> None:
         """\brief Play any named gesture via the controller's gesture engine."""

--- a/Server/core/movement/controller.py
+++ b/Server/core/movement/controller.py
@@ -79,6 +79,12 @@ class GestureCmd:
     name: str  # e.g., "greet"
 
 
+@dataclass
+class GreetCmd:
+    """Play the default greeting gesture."""
+    pass
+
+
 Command = Union[
     WalkCmd,
     StepCmd,
@@ -89,6 +95,7 @@ Command = Union[
     StopCmd,
     RelaxCmd,
     GestureCmd,
+    GreetCmd,
 ]
 
 
@@ -373,7 +380,7 @@ class MovementController:
 
     # ------------------------------------------------------------------
     def _process_command(self, cmd: Command) -> None:
-        if isinstance(cmd, (WalkCmd, StepCmd, TurnCmd, HeightCmd, AttitudeCmd, StopCmd, GestureCmd, HeadCmd)):
+        if isinstance(cmd, (WalkCmd, StepCmd, TurnCmd, HeightCmd, AttitudeCmd, StopCmd, GestureCmd, GreetCmd, HeadCmd)):
             self._in_relax = False
         if isinstance(cmd, WalkCmd):
             self.stop_requested = False
@@ -443,6 +450,10 @@ class MovementController:
         elif isinstance(cmd, GestureCmd):
             self._in_relax = False
             self._play_gesture(cmd.name)
+            self._active_cmd = None
+        elif isinstance(cmd, GreetCmd):
+            self._in_relax = False
+            self._play_gesture("greet")
             self._active_cmd = None
         elif isinstance(cmd, HeadCmd):
             self._in_relax = False


### PR DESCRIPTION
## Summary
- add GreetCmd dataclass to represent default greeting gesture
- handle GreetCmd in command union and processing logic
- use GreetCmd in MovementControl.greet

## Testing
- `python -m py_compile Server/core/MovementControl.py Server/core/movement/controller.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'network')*


------
https://chatgpt.com/codex/tasks/task_e_68aee0b0bd50832ebc6581b0fc847d34