### PR TITLE
Use internal controller for head limits

### DIFF
--- a/Server/core/MovementControl.py
+++ b/Server/core/MovementControl.py
@@ -94,6 +94,12 @@ class MovementControl:
         """\brief Play any named gesture via the controller's gesture engine."""
         self.controller.queue.put(GestureCmd(name=name))
 
+    @property
+    def head_limits(self) -> tuple[float, float, float]:
+        """Expose head min, max, and center angles from the internal controller."""
+        c = self.controller
+        return c.head_min_deg, c.head_max_deg, c.head_center_deg
+
     def set_speed(self, speed: int) -> None:
         """\brief Set the controller speed.
 

--- a/Server/test_codes/test_gamepad.py
+++ b/Server/test_codes/test_gamepad.py
@@ -26,8 +26,8 @@ def polling_loop(gamepad, controller):
             y1 = gamepad.axis(4)
 
             if abs(y1) > DEADZONE:
-                span = controller.head_max_deg - controller.head_min_deg
-                angle = controller.head_center_deg + y1 * span / 2
+                span = controller.controller.head_max_deg - controller.controller.head_min_deg
+                angle = controller.controller.head_center_deg + y1 * span / 2
                 controller.head(angle)
 
             if abs(x0) > DEADZONE or abs(y0) > DEADZONE:


### PR DESCRIPTION
## Summary
- Adjust gamepad polling to read head limits from the internal controller instance
- Expose MovementControl.head_limits helper to access controller head range

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'network')*

------
https://chatgpt.com/codex/tasks/task_e_68af0d9c2f38832eb9d16210b09f8b97