### PR TITLE
Rename Camera to VisionInterface

### DIFF
--- a/Server/core/VisionInterface.py
+++ b/Server/core/VisionInterface.py
@@ -10,9 +10,9 @@ import time
 import os
 
 
-class Camera:
+class VisionInterface:
     """
-    @brief Camera wrapper using Picamera2 with a periodic vision pipeline.
+    @brief Vision interface wrapper using Picamera2 with a periodic vision pipeline.
     @details
     Captures frames at resolution defined in ``CAMERA_RESOLUTION``, runs a detection pipeline, draws overlays,
     and exposes the last processed frame as a base64-encoded JPEG string.
@@ -141,7 +141,7 @@ class Camera:
         @note Stores the last processed frame as base64 JPEG in _last_encoded_image.
         """
         if self._streaming:
-            print("[Camera] Streaming already running.")
+            print("[VisionInterface] Streaming already running.")
             return
         self._streaming = True
         self._ensure_camera_started()
@@ -161,7 +161,7 @@ class Camera:
                         with self._lock:
                             self._last_encoded_image = encoded
                 except Exception as e:
-                    print(f"[Camera] Error in periodic capture: {e}")
+                    print(f"[VisionInterface] Error in periodic capture: {e}")
 
                 # Compensate processing time to keep cadence
                 sleep_s = next_tick - time.monotonic()
@@ -173,7 +173,7 @@ class Camera:
 
         self._thread = threading.Thread(target=_capture_loop, daemon=True)
         self._thread.start()
-        print("[Camera] Started periodic capture.")
+        print("[VisionInterface] Started periodic capture.")
 
     def stop_periodic_capture(self):
         """
@@ -186,7 +186,7 @@ class Camera:
         self._ensure_camera_stopped()
         if self._logger:
             self._logger.close()
-        print("[Camera] Stopped periodic capture.")
+        print("[VisionInterface] Stopped periodic capture.")
 
     def get_last_processed_encoded(self):
         """

--- a/Server/network/ws_server.py
+++ b/Server/network/ws_server.py
@@ -4,10 +4,10 @@ import json
 import time
 import websockets
 
-from core.Camera import Camera
+from core.VisionInterface import VisionInterface
 from core.vision import api as vision_api
 
-camera = Camera()
+camera = VisionInterface()
 camera.start_periodic_capture(interval=1.0)  # sigue autoarrancando; si prefieres lazy, quita esta línea
 
 

--- a/Server/test_codes/test_visual_perception.py
+++ b/Server/test_codes/test_visual_perception.py
@@ -1,8 +1,8 @@
-from Camera import Camera
+from VisionInterface import VisionInterface
 import base64, datetime, os, time
 
 def main():
-    cam = Camera()
+    cam = VisionInterface()
     os.makedirs("logs", exist_ok=True)
     ts = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
     filename = f"logs/{ts}.jpg"


### PR DESCRIPTION
## Summary
- rename Camera module to VisionInterface and update logging
- update imports to use new VisionInterface class

## Testing
- `pytest`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af2c009b28832ea482f922d1ba72e2