### PR TITLE
Refactor vision detectors to protocol interface

### DIFF
--- a/Server/core/vision/detectors/README.md
+++ b/Server/core/vision/detectors/README.md
@@ -1,6 +1,6 @@
 # Vision Pipeline — ContourDetector + Temporal API
 
-Resumen conciso del pipeline y tuning. Paridad con `contour_detector.py` y `api.py`.
+Resumen conciso del pipeline y tuning. Paridad con `contours.py` y `api.py`.
 
 ## Pipeline
 1) **Preprocesado** → resize (proc_w,h), gris, blur impar.  
@@ -23,9 +23,9 @@ Resumen conciso del pipeline y tuning. Paridad con `contour_detector.py` y `api.
 
 ## Uso
 ```python
-from core.vision.detectors.contour_detector import ContourDetector
-det = ContourDetector.from_profile("profile_big_solid.json")
-res = det.detect(frame_bgr, return_overlay=True)
+from core.vision.detectors.contours import ContourDetector
+det = ContourDetector()
+res = det.infer(frame_bgr, {"return_overlay": True})
 
 from core.vision.api import process_frame
 out = process_frame(frame_bgr, return_overlay=True, config={"roi_factor":1.8, "ema":0.7})

--- a/Server/core/vision/detectors/base.py
+++ b/Server/core/vision/detectors/base.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional, Protocol, Tuple
+
+import numpy as np
+
+
+@dataclass
+class DetectionResult:
+    ok: bool
+    used_rescue: bool
+    life_canny_pct: float
+    bbox: Optional[Tuple[int, int, int, int]] = None
+    score: Optional[float] = None
+    fill: Optional[float] = None
+    bbox_ratio: Optional[float] = None
+    chosen_ck: Optional[int] = None
+    chosen_dk: Optional[int] = None
+    center: Optional[Tuple[int, int]] = None
+    overlay: Optional[np.ndarray] = None
+    t1: Optional[float] = None
+    t2: Optional[int] = None
+    color_cover_pct: Optional[float] = None
+    color_used: Optional[bool] = None
+
+
+class Detector(Protocol):
+    """Interface for vision detectors."""
+
+    name: str
+
+    def configure(self, cfg: Any) -> None:
+        """Configure detector using a configuration object or dict."""
+
+    def infer(self, frame: np.ndarray, ctx: Optional[Any] = None) -> DetectionResult:
+        """Run detection on a frame and return a :class:`DetectionResult`."""

--- a/Server/core/vision/detectors/face.py
+++ b/Server/core/vision/detectors/face.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import numpy as np
+
+from .base import Detector, DetectionResult
+
+
+class FaceDetector(Detector):
+    """Placeholder face detector using Haar or DNN classifiers."""
+
+    name = "face"
+
+    def __init__(self) -> None:
+        self.cascade = None
+        self.net = None
+
+    def configure(self, cfg: Any) -> None:
+        if isinstance(cfg, dict):
+            self.cascade = cfg.get("cascade")
+            self.net = cfg.get("net")
+
+    def infer(self, frame: np.ndarray, ctx: Optional[Any] = None) -> DetectionResult:
+        # Stub: real implementation would run cascade or DNN classifiers
+        return DetectionResult(ok=False, used_rescue=False, life_canny_pct=0.0)

--- a/Server/core/vision/viz_logger.py
+++ b/Server/core/vision/viz_logger.py
@@ -3,7 +3,8 @@ from typing import Optional, Tuple
 import numpy as np
 
 from .engine import VisionEngine
-from .detectors.contour_detector import ContourDetector, DetectionResult
+from .detectors.contours import ContourDetector
+from .detectors.base import DetectionResult
 
 def _ref_size(det: ContourDetector) -> Tuple[int,int]:
     return det.proc.proc_w, det.proc.proc_h
@@ -46,8 +47,12 @@ class VisionLogger:
         if (self.idx % self.stride) != 0:
             return  # no hacer nada este frame
 
-        res = det.detect(frame_bgr, save_dir=self.run_dir, stamp=stamp,
-                         save_profile=True, return_overlay=False)
+        res = det.infer(frame_bgr, {
+            "save_dir": self.run_dir,
+            "stamp": stamp,
+            "save_profile": True,
+            "return_overlay": False,
+        })
 
         x=y=w=h=0
         if res.bbox: x,y,w,h = res.bbox
@@ -86,9 +91,14 @@ class VisionLogger:
         save_dir = self.run_dir if (self.idx % self.stride == 0) else None
 
         # Ejecutamos el detector elegido sobre el frame completo para logging.
-        res: DetectionResult = det.detect(
-            frame_bgr, save_dir=save_dir, stamp=stamp,
-            save_profile=True, return_overlay=True
+        res: DetectionResult = det.infer(
+            frame_bgr,
+            {
+                "save_dir": save_dir,
+                "stamp": stamp,
+                "save_profile": True,
+                "return_overlay": True,
+            },
         )
 
         # Escribir CSV


### PR DESCRIPTION
## Summary
- introduce `Detector` protocol and `DetectionResult` dataclass for vision modules
- refactor contour detector into `contours` module with `configure`/`infer` API
- add stub `FaceDetector` and update engine and logger to use new detector interface

## Testing
- `python -m py_compile Server/core/vision/detectors/base.py Server/core/vision/detectors/face.py Server/core/vision/detectors/contours.py Server/core/vision/engine.py Server/core/vision/viz_logger.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'network')*

------
https://chatgpt.com/codex/tasks/task_e_68b05c1233a4832e9dd7cc0bfca7e466