### PR TITLE
Centralize vision overlay rendering

### DIFF
--- a/Server/core/vision/engine.py
+++ b/Server/core/vision/engine.py
@@ -198,7 +198,7 @@ class VisionEngine:
 
         if self.logger is not None:
             try:
-                self.logger.log(frame, res, res.get("overlay"))
+                self.logger.log(frame, res)
             except Exception:
                 pass
         return res

--- a/Server/core/vision/imgproc.py
+++ b/Server/core/vision/imgproc.py
@@ -292,30 +292,6 @@ def _try_with_margins(edges: NDArray, proc_cfg: "ProcConfig", morph_cfg: "MorphC
     return best, e_used
 
 
-def _draw_overlay(proc_bgr: NDArray, info: Dict[str, Any], mask_final: NDArray, color_enabled: bool) -> Tuple[NDArray, Tuple[int, int]]:
-    """
-    @brief Draw detection overlay on processed image.
-    @param proc_bgr NDArray Processed BGR image.
-    @param info Dict[str,Any] Selected contour information.
-    @param mask_final NDArray Mask image where contour will be drawn.
-    @param color_enabled bool Whether color gate is enabled.
-    @return Tuple[NDArray,Tuple[int,int]] Overlay image and contour center.
-    """
-    overlay = proc_bgr.copy()
-    x, y, w, h = info["bbox"]
-    cv2.drawContours(mask_final, [info["cnt"]], -1, 255, thickness=cv2.FILLED)
-    cv2.rectangle(overlay, (x, y), (x + w, y + h), (0, 255, 0), 2)
-    M = cv2.moments(info["cnt"])
-    c = (x + w // 2, y + h // 2)
-    if M["m00"] != 0:
-        c = (int(M["m10"] / M["m00"]), int(M["m01"] / M["m00"]))
-    cv2.circle(overlay, c, 4, (0, 255, 0), -1)
-    tag = "color_gate" if color_enabled else "canny"
-    txt = f"{tag}  fill={info['fill']:.2f}  bbox={info['bbox_ratio']:.2f}  sc={info['score']:.2f}"
-    cv2.putText(overlay, txt, (x, max(18, y - 6)), cv2.FONT_HERSHEY_SIMPLEX, 0.5, (0, 255, 0), 2)
-    return overlay, c
-
-
 def _color_gate(bgr: NDArray, color_cfg: "ColorGateConfig") -> NDArray:
     """
     @brief Generate mask by filtering colors.

--- a/Server/core/vision/logger.py
+++ b/Server/core/vision/logger.py
@@ -6,6 +6,8 @@ from typing import Optional, Dict, Any, TYPE_CHECKING
 import cv2
 import numpy as np
 
+from .overlays import draw_engine
+
 if TYPE_CHECKING:  # pragma: no cover - for type checking only
     from .engine import EngineResult
 
@@ -63,9 +65,11 @@ class VizLogger:
             cv2.imwrite(os.path.join(self.run_dir, raw_name), frame_bgr)
             data["raw"] = raw_name
 
-        # Use explicit overlay argument if given, otherwise result['overlay']
-        if overlay is None and isinstance(result, dict):
-            overlay = result.get("overlay")  # type: ignore[assignment]
+        if overlay is None and frame_bgr is not None:
+            try:
+                overlay = draw_engine(frame_bgr, result)
+            except Exception:
+                overlay = None
         if overlay is not None:
             ov_name = f"{stamp}_overlay.png"
             cv2.imwrite(os.path.join(self.run_dir, ov_name), overlay)

--- a/Server/core/vision/overlays.py
+++ b/Server/core/vision/overlays.py
@@ -1,0 +1,83 @@
+"""
+@file overlays.py
+@brief Helpers for drawing vision overlays.
+
+This module centralises overlay rendering so that different components can
+share the same drawing logic without duplicating code.
+"""
+from __future__ import annotations
+
+from typing import Mapping, Any
+
+import cv2
+import numpy as np
+
+NDArray = np.ndarray
+
+
+# ---------------------------------------------------------------------------
+
+def draw_detector(frame: NDArray, det_result: Mapping[str, Any]) -> NDArray:
+    """
+    @brief Render detector information on ``frame``.
+    @param frame NDArray Base image where annotations will be drawn.
+    @param det_result Mapping[str,Any] Detection result containing at least
+                      ``bbox``, ``center``, ``fill``, ``bbox_ratio`` and
+                      ``score`` keys.
+    @return NDArray Overlay image.
+    """
+    overlay = frame.copy()
+    bbox = det_result.get("bbox")
+    if bbox is None:
+        return overlay
+    x, y, w, h = bbox
+    cv2.rectangle(overlay, (x, y), (x + w, y + h), (0, 255, 0), 2)
+
+    center = det_result.get("center")
+    if center is not None:
+        cv2.circle(overlay, tuple(int(v) for v in center), 4, (0, 255, 0), -1)
+
+    fill = det_result.get("fill")
+    bbox_ratio = det_result.get("bbox_ratio")
+    score = det_result.get("score")
+    if None not in (fill, bbox_ratio, score):
+        tag = "color_gate" if det_result.get("color_used") else "canny"
+        txt = f"{tag}  fill={float(fill):.2f}  bbox={float(bbox_ratio):.2f}  sc={float(score):.2f}"
+        cv2.putText(overlay, txt, (x, max(18, y - 6)), cv2.FONT_HERSHEY_SIMPLEX, 0.5, (0, 255, 0), 2)
+    return overlay
+
+
+def draw_engine(frame: NDArray, result: Mapping[str, Any]) -> NDArray:
+    """
+    @brief Draw an engine result on top of ``frame``.
+    @param frame NDArray Original BGR frame.
+    @param result Mapping[str,Any] Engine result as returned by ``VisionEngine``.
+    @return NDArray Image with rendered overlay.
+    """
+    overlay = frame.copy()
+    if not result or not result.get("ok"):
+        return overlay
+
+    space = result.get("space") or (frame.shape[1], frame.shape[0])
+    ref_w, ref_h = space
+    sx = frame.shape[1] / float(ref_w)
+    sy = frame.shape[0] / float(ref_h)
+
+    bbox = result.get("bbox")
+    if bbox is None:
+        return overlay
+    x, y, w, h = bbox
+    x2, y2, w2, h2 = int(x * sx), int(y * sy), int(w * sx), int(h * sy)
+    cv2.rectangle(overlay, (x2, y2), (x2 + w2, y2 + h2), (0, 255, 0), 2)
+
+    center = result.get("center")
+    if center is not None:
+        cx, cy = center
+        cv2.circle(overlay, (int(cx * sx), int(cy * sy)), 4, (0, 255, 0), -1)
+
+    score = result.get("score")
+    if score is not None:
+        label_y = max(18, y2 - 6)
+        cv2.putText(overlay, f"sc={float(score):.2f}", (10, label_y),
+                    cv2.FONT_HERSHEY_SIMPLEX, 0.6, (0, 255, 0), 2)
+    return overlay


### PR DESCRIPTION
## Summary
- Add `overlays.py` with reusable `draw_detector` and `draw_engine` helpers
- Route contour detector, `VisionInterface`, and `VizLogger` through overlay helpers
- Simplify logging and interface by delegating overlay creation

## Testing
- `python -m py_compile Server/core/VisionInterface.py Server/core/vision/detectors/contours.py Server/core/vision/engine.py Server/core/vision/imgproc.py Server/core/vision/logger.py Server/core/vision/overlays.py`
- `pytest` *(fails: No module named 'network', No module named 'gui', No module named 'numpy', No module named 'spidev', No module named 'picamera2')*

------
https://chatgpt.com/codex/tasks/task_e_68b061fb8d84832e8720c4f1ee067153