### PR TITLE
refactor: add vision engine facade

### DIFF
--- a/Server/network/ws_server.py
+++ b/Server/network/ws_server.py
@@ -6,8 +6,12 @@ import websockets
 
 from core.VisionInterface import VisionInterface
 from core.vision import api as vision_api
+from core.vision.engine import DynamicParams
 
-camera = VisionInterface()
+# Instantiate the vision engine through the façade and wire it into the
+# camera interface.  This replaces the previous implicit global engine.
+engine = vision_api.create_engine_from_config()
+camera = VisionInterface(engine)
 camera.start_periodic_capture(interval=1.0)  # sigue autoarrancando; si prefieres lazy, quita esta línea
 
 
@@ -65,16 +69,10 @@ async def handler(websocket):
                 camera.set_processing_config(config)
                 response = {"status": "ok", "type": "text", "data": "processing config updated"}
 
-            elif cmd == "load_profile":
-                which = data.get("which", "big")
-                path = data.get("path")
-                vision_api.load_profile(which, path)
-                response = {"status": "ok", "type": "text", "data": f"profile {which} loaded"}
-
             elif cmd == "dynamic":
                 which = data.get("which", "big")
                 params = data.get("params", {})
-                vision_api.update_dynamic(which, params)
+                vision_api.set_dynamic(DynamicParams(which, params))
                 response = {"status": "ok", "type": "text", "data": "dynamic params updated"}
 
             else:

--- a/Server/test_codes/test_visual_perception.py
+++ b/Server/test_codes/test_visual_perception.py
@@ -1,8 +1,11 @@
-from VisionInterface import VisionInterface
+from core.VisionInterface import VisionInterface
+from core.vision import api as vision_api
+
 import base64, datetime, os, time
 
 def main():
-    cam = VisionInterface()
+    engine = vision_api.create_engine_from_config()
+    cam = VisionInterface(engine)
     os.makedirs("logs", exist_ok=True)
     ts = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
     filename = f"logs/{ts}.jpg"


### PR DESCRIPTION
## Summary
- add a thin façade around `VisionEngine` to create it from config, update dynamics and fetch results
- wire WebSocket server and vision tests to use the new façade

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'network')*

------
https://chatgpt.com/codex/tasks/task_e_68b064ce5004832ea3c3c0987fde6088