### PR TITLE
refactor vision modules to use dataclasses and snake_case

### DIFF
--- a/Server/core/vision/api.py
+++ b/Server/core/vision/api.py
@@ -60,10 +60,9 @@ def set_dynamic(params: DynamicParams) -> None:
 def get_last_result() -> EngineResult:
     """Return the last result computed by the engine.
 
-    If the engine has not yet processed any frame, an empty result with
-    ``{"ok": False}`` is returned instead of ``None`` to maintain a stable
-    return type.
+    Returns:
+        EngineResult: Last result or an empty negative result if none.
     """
     engine = _require_engine()
     result = engine.get_last_result()
-    return result or {"ok": False}
+    return result or EngineResult(ok=False)

--- a/Server/core/vision/detectors/base.py
+++ b/Server/core/vision/detectors/base.py
@@ -8,6 +8,8 @@ import numpy as np
 
 @dataclass
 class DetectionResult:
+    """Structured result returned by a detector."""
+
     ok: bool
     used_rescue: bool
     life_canny_pct: float
@@ -25,13 +27,38 @@ class DetectionResult:
     color_used: Optional[bool] = None
 
 
+@dataclass
+class DetectionContext:
+    """Execution context passed to detectors.
+
+    Attributes:
+        save_dir: Directory where intermediate images will be stored.
+        stamp: Prefix for saved files within ``save_dir``.
+        save_profile: Whether to persist profile snapshots.
+        return_overlay: Whether detectors should return overlay images.
+    """
+
+    save_dir: Optional[str] = None
+    stamp: Optional[str] = None
+    save_profile: bool = True
+    return_overlay: bool = True
+
+
 class Detector(Protocol):
     """Interface for vision detectors."""
 
     name: str
 
     def configure(self, cfg: Any) -> None:
-        """Configure detector using a configuration object or dict."""
+        """Configure detector using a configuration object or dictionary."""
 
-    def infer(self, frame: np.ndarray, ctx: Optional[Any] = None) -> DetectionResult:
-        """Run detection on a frame and return a :class:`DetectionResult`."""
+    def infer(self, frame: np.ndarray, ctx: Optional[DetectionContext] = None) -> DetectionResult:
+        """Run detection on ``frame``.
+
+        Args:
+            frame: BGR image in NumPy array format.
+            ctx: Optional execution context.
+
+        Returns:
+            DetectionResult: Structured detection output.
+        """

--- a/Server/core/vision/detectors/face.py
+++ b/Server/core/vision/detectors/face.py
@@ -4,7 +4,7 @@ from typing import Any, Optional
 
 import numpy as np
 
-from .base import Detector, DetectionResult
+from .base import Detector, DetectionResult, DetectionContext
 
 
 class FaceDetector(Detector):
@@ -17,10 +17,23 @@ class FaceDetector(Detector):
         self.net = None
 
     def configure(self, cfg: Any) -> None:
+        """Configure the detector.
+
+        Args:
+            cfg: Arbitrary configuration mapping.
+        """
         if isinstance(cfg, dict):
             self.cascade = cfg.get("cascade")
             self.net = cfg.get("net")
 
-    def infer(self, frame: np.ndarray, ctx: Optional[Any] = None) -> DetectionResult:
-        # Stub: real implementation would run cascade or DNN classifiers
+    def infer(self, frame: np.ndarray, ctx: Optional[DetectionContext] = None) -> DetectionResult:
+        """Run detection on ``frame``.
+
+        Args:
+            frame: BGR image to analyse.
+            ctx: Optional execution context (unused).
+
+        Returns:
+            DetectionResult: Always a negative placeholder result.
+        """
         return DetectionResult(ok=False, used_rescue=False, life_canny_pct=0.0)

--- a/Server/core/vision/logger.py
+++ b/Server/core/vision/logger.py
@@ -1,6 +1,7 @@
 import os
 import time
 import json
+from dataclasses import asdict, is_dataclass
 from typing import Optional, Dict, Any, TYPE_CHECKING
 
 import cv2
@@ -49,7 +50,8 @@ class VizLogger:
         data: Dict[str, Any] = {"frame": self.idx, "ts": time.time()}
 
         # Copy result, normalising types and skipping the overlay array
-        for k, v in dict(result or {}).items():
+        res_dict = asdict(result) if is_dataclass(result) else dict(result or {})
+        for k, v in res_dict.items():
             if k == "overlay":
                 continue
             if isinstance(v, np.generic):

--- a/Server/core/vision/overlays.py
+++ b/Server/core/vision/overlays.py
@@ -7,75 +7,86 @@ share the same drawing logic without duplicating code.
 """
 from __future__ import annotations
 
-from typing import Mapping, Any
+from typing import Mapping, Any, TYPE_CHECKING
+from dataclasses import asdict, is_dataclass
 
 import cv2
 import numpy as np
 
 NDArray = np.ndarray
 
+if TYPE_CHECKING:  # pragma: no cover
+    from .engine import EngineResult
+    from .detectors.base import DetectionResult
+
 
 # ---------------------------------------------------------------------------
 
-def draw_detector(frame: NDArray, det_result: Mapping[str, Any]) -> NDArray:
-    """
-    @brief Render detector information on ``frame``.
-    @param frame NDArray Base image where annotations will be drawn.
-    @param det_result Mapping[str,Any] Detection result containing at least
-                      ``bbox``, ``center``, ``fill``, ``bbox_ratio`` and
-                      ``score`` keys.
-    @return NDArray Overlay image.
+def draw_detector(frame: NDArray, det_result: Mapping[str, Any] | "DetectionResult") -> NDArray:
+    """Render detector information on ``frame``.
+
+    Args:
+        frame: Base image where annotations will be drawn.
+        det_result: Detection result containing at least ``bbox`` and ``score``.
+
+    Returns:
+        Overlay image.
     """
     overlay = frame.copy()
-    bbox = det_result.get("bbox")
+    data = asdict(det_result) if is_dataclass(det_result) else dict(det_result)
+    bbox = data.get("bbox")
     if bbox is None:
         return overlay
     x, y, w, h = bbox
     cv2.rectangle(overlay, (x, y), (x + w, y + h), (0, 255, 0), 2)
 
-    center = det_result.get("center")
+    center = data.get("center")
     if center is not None:
         cv2.circle(overlay, tuple(int(v) for v in center), 4, (0, 255, 0), -1)
 
-    fill = det_result.get("fill")
-    bbox_ratio = det_result.get("bbox_ratio")
-    score = det_result.get("score")
+    fill = data.get("fill")
+    bbox_ratio = data.get("bbox_ratio")
+    score = data.get("score")
     if None not in (fill, bbox_ratio, score):
-        tag = "color_gate" if det_result.get("color_used") else "canny"
+        tag = "color_gate" if data.get("color_used") else "canny"
         txt = f"{tag}  fill={float(fill):.2f}  bbox={float(bbox_ratio):.2f}  sc={float(score):.2f}"
         cv2.putText(overlay, txt, (x, max(18, y - 6)), cv2.FONT_HERSHEY_SIMPLEX, 0.5, (0, 255, 0), 2)
     return overlay
 
 
-def draw_engine(frame: NDArray, result: Mapping[str, Any]) -> NDArray:
-    """
-    @brief Draw an engine result on top of ``frame``.
-    @param frame NDArray Original BGR frame.
-    @param result Mapping[str,Any] Engine result as returned by ``VisionEngine``.
-    @return NDArray Image with rendered overlay.
+def draw_engine(frame: NDArray, result: Mapping[str, Any] | "EngineResult") -> NDArray:
+    """Draw an engine result on top of ``frame``.
+
+    Args:
+        frame: Original BGR frame.
+        result: Engine result as returned by ``VisionEngine``.
+
+    Returns:
+        Image with rendered overlay.
     """
     overlay = frame.copy()
-    if not result or not result.get("ok"):
+    data = asdict(result) if is_dataclass(result) else dict(result)
+    if not data or not data.get("ok"):
         return overlay
 
-    space = result.get("space") or (frame.shape[1], frame.shape[0])
+    space = data.get("space") or (frame.shape[1], frame.shape[0])
     ref_w, ref_h = space
     sx = frame.shape[1] / float(ref_w)
     sy = frame.shape[0] / float(ref_h)
 
-    bbox = result.get("bbox")
+    bbox = data.get("bbox")
     if bbox is None:
         return overlay
     x, y, w, h = bbox
     x2, y2, w2, h2 = int(x * sx), int(y * sy), int(w * sx), int(h * sy)
     cv2.rectangle(overlay, (x2, y2), (x2 + w2, y2 + h2), (0, 255, 0), 2)
 
-    center = result.get("center")
+    center = data.get("center")
     if center is not None:
         cx, cy = center
         cv2.circle(overlay, (int(cx * sx), int(cy * sy)), 4, (0, 255, 0), -1)
 
-    score = result.get("score")
+    score = data.get("score")
     if score is not None:
         label_y = max(18, y2 - 6)
         cv2.putText(overlay, f"sc={float(score):.2f}", (10, label_y),


### PR DESCRIPTION
## Summary
- standardize vision API structures with dataclasses
- rename internals to snake_case for consistency
- add Google-style docstrings and type hints across vision modules

## Testing
- `python -m py_compile Server/core/vision/api.py Server/core/vision/detectors/base.py Server/core/vision/detectors/contours.py Server/core/vision/detectors/face.py Server/core/vision/engine.py Server/core/vision/imgproc.py Server/core/vision/logger.py Server/core/vision/overlays.py`
- `pytest` *(fails: 9 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b06722c764832ea928ff10cc0beab5