### PR TITLE
refactor: centralize vision config path

### DIFF
--- a/Server/core/vision/api.py
+++ b/Server/core/vision/api.py
@@ -36,15 +36,15 @@ def _require_engine() -> VisionEngine:
     return _engine
 
 
-def create_engine_from_config(path: str = "configs/vision.yaml") -> VisionEngine:
+def create_engine_from_config(path: Optional[str] = None) -> VisionEngine:
     """Create and store a :class:`VisionEngine` from the given YAML file.
 
     Parameters
     ----------
     path:
-        Location of the YAML configuration file. The default mirrors the
-        previous behaviour of looking for ``configs/vision.yaml`` relative to
-        the working directory.
+        Optional location of the YAML configuration file. If ``None`` or a
+        relative path is provided, the default configuration bundled with the
+        package is used.
     """
     global _engine
     cfg = merge_with_defaults(load_config(path))

--- a/Server/core/vision/config.py
+++ b/Server/core/vision/config.py
@@ -85,6 +85,9 @@ BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 _PROFILE_DIR = os.path.join(BASE_DIR, "profiles")
 _DEFAULT_BIG = os.path.join(_PROFILE_DIR, "profile_big.json")
 _DEFAULT_SMALL = os.path.join(_PROFILE_DIR, "profile_small.json")
+DEFAULT_CONFIG_PATH = os.path.abspath(
+    os.path.join(BASE_DIR, "..", "..", "..", "configs", "vision.yaml")
+)
 
 
 @dataclass
@@ -329,8 +332,19 @@ def merge_with_defaults(cfg: Optional[VisionConfig] = None) -> VisionConfig:
     return _merge(base, cfg)
 
 
-def load_config(path: str) -> VisionConfig:
-    """Load a YAML configuration file and return a ``VisionConfig`` instance."""
+def load_config(path: Optional[str] = None) -> VisionConfig:
+    """Load a YAML configuration file and return a ``VisionConfig`` instance.
+
+    Parameters
+    ----------
+    path:
+        Optional path to the configuration file. If ``None`` or a relative
+        path, the file is resolved relative to ``DEFAULT_CONFIG_PATH``.
+    """
+    if path is None:
+        path = DEFAULT_CONFIG_PATH
+    elif not os.path.isabs(path):
+        path = os.path.join(os.path.dirname(DEFAULT_CONFIG_PATH), path)
 
     with open(path, "r", encoding="utf-8") as fh:
         text = fh.read()


### PR DESCRIPTION
## Summary
- add DEFAULT_CONFIG_PATH for vision subsystem
- allow load_config to resolve missing or relative paths to default
- use load_config default in create_engine_from_config

## Testing
- `python -m pytest` *(fails: No module named 'network', 'gui', 'numpy', 'spidev')*


------
https://chatgpt.com/codex/tasks/task_e_68b06fb7d644832eb0b5530f1d979c43