### PR TITLE
feat: update vision config path

### DIFF
--- a/Server/core/vision/config.py
+++ b/Server/core/vision/config.py
@@ -85,9 +85,7 @@ BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 _PROFILE_DIR = os.path.join(BASE_DIR, "profiles")
 _DEFAULT_BIG = os.path.join(_PROFILE_DIR, "profile_big.json")
 _DEFAULT_SMALL = os.path.join(_PROFILE_DIR, "profile_small.json")
-DEFAULT_CONFIG_PATH = os.path.abspath(
-    os.path.join(BASE_DIR, "..", "..", "..", "configs", "vision.yaml")
-)
+DEFAULT_CONFIG_PATH = os.path.join(BASE_DIR, "config", "vision.yaml")
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- update DEFAULT_CONFIG_PATH to new vision config directory
- keep load_config relative path resolution

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'network')*

------
https://chatgpt.com/codex/tasks/task_e_68b073d2b98c832e87a63c532119df43