### PR TITLE
Handle empty engine configuration in vision settings

### DIFF
--- a/Server/core/vision/config.py
+++ b/Server/core/vision/config.py
@@ -255,7 +255,7 @@ def load_config(path: Optional[str] = None) -> VisionConfig:
         raw = yaml.safe_load(text) or {}
 
     cfg = VisionConfig(
-        engine=_strict(EngineConfig, raw.get("engine", {})),
+        engine=_strict(EngineConfig, raw.get("engine") or {}),
         detectors=DetectorsConfig(
             big=_strict(DetectorConfig, raw.get("detectors", {}).get("big", {})),
             small=_strict(DetectorConfig, raw.get("detectors", {}).get("small", {})),

--- a/Server/core/vision/config/vision.yaml
+++ b/Server/core/vision/config/vision.yaml
@@ -3,7 +3,7 @@
 # The detectors section includes the default parameters formerly provided by
 # the separate profile files. Adjust as needed.
 
-engine:
+engine: {}
   # stable: true
   # on_th: 0.55
   # off_th: 0.45


### PR DESCRIPTION
## Summary
- Ensure `vision.yaml` defines an empty mapping for the engine block
- Treat `None` engine values as an empty mapping when loading configuration

## Testing
- `python - <<'PY'
import sys
sys.path.insert(0, 'Server')
from core.vision.config import load_config
cfg = load_config()
print(cfg)
PY`
- `python Server/run.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68b07959367c832eafea751ba7d77454