### PR TITLE
Handle optional logging config

### DIFF
--- a/Server/core/vision/config.py
+++ b/Server/core/vision/config.py
@@ -260,7 +260,7 @@ def load_config(path: Optional[str] = None) -> VisionConfig:
             big=_strict(DetectorConfig, raw.get("detectors", {}).get("big", {})),
             small=_strict(DetectorConfig, raw.get("detectors", {}).get("small", {})),
         ),
-        logging=_strict(LoggingConfig, raw.get("logging", {})),
+        logging=_strict(LoggingConfig, raw.get("logging") or {}),
     )
     return merge_with_defaults(cfg)
 

--- a/Server/core/vision/config/vision.yaml
+++ b/Server/core/vision/config/vision.yaml
@@ -117,7 +117,7 @@ detectors:
       min_cover_pct: 0.5
       max_cover_pct: 60.0
 
-logging:
+logging: {}
   # output_dir: runs/vision
   # stride: 5
   # save_raw: false


### PR DESCRIPTION
## Summary
- guard against null logging sections when loading vision config
- ensure default vision.yaml explicitly defines an empty logging mapping

## Testing
- `python - <<'PY'
import os, sys
project_root = os.path.join(os.getcwd(), 'Server')
for folder in ['', 'core', 'lib', 'test_codes', 'network']:
    folder_path = os.path.join(project_root, folder)
    if folder_path not in sys.path:
        sys.path.insert(0, folder_path)
from core.vision.config import load_config
load_config()
print('config loaded')
PY`
- `python Server/run.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68b07b6f2c3c832eab0368d87f2926e5