### PR TITLE
Enforce strict dataclass configs for vision

### DIFF
--- a/Server/core/vision/api.py
+++ b/Server/core/vision/api.py
@@ -23,7 +23,7 @@ from typing import Optional
 from dataclasses import asdict
 
 from .engine import VisionEngine, DynamicParams, EngineResult
-from .config import load_config, merge_with_defaults
+from .config import load_config
 from .logger import VizLogger
 
 _engine: Optional[VisionEngine] = None
@@ -47,7 +47,7 @@ def create_engine_from_config(path: Optional[str] = None) -> VisionEngine:
         package is used.
     """
     global _engine
-    cfg = merge_with_defaults(load_config(path))
+    cfg = load_config(path)
     logger = VizLogger(**asdict(cfg.logging))
     _engine = VisionEngine(cfg, logger=logger)
     return _engine


### PR DESCRIPTION
## Summary
- ensure _merge only operates on dataclasses and raise on dict inputs
- build vision configs with recursive `_strict` so nested sections become dataclasses
- drop redundant `merge_with_defaults(load_config())` in API facade

## Testing
- `python -m py_compile Server/core/vision/config.py Server/core/vision/api.py`
- `pytest` *(fails: ModuleNotFoundError for network, numpy, spidev etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b07d6c8c24832ea4092b4e57fc1702