### PR TITLE
Rename Camera module to VisionInterface

### DIFF
--- a/Client/gui/widgets/stream_widget.py
+++ b/Client/gui/widgets/stream_widget.py
@@ -6,7 +6,7 @@ from PyQt6.QtWidgets import QLabel, QVBoxLayout, QWidget
 class StreamWidget(QWidget):
     def __init__(self, ws_client):
         super().__init__()
-        self.setWindowTitle("Robot Camera Stream")
+        self.setWindowTitle("Robot Vision Stream")
         self.layout = QVBoxLayout()
         self.image_label = QLabel()
         self.image_label.setAlignment(Qt.AlignmentFlag.AlignCenter)

--- a/Server/core/VisionInterface.py
+++ b/Server/core/VisionInterface.py
@@ -10,9 +10,9 @@ import time
 import os
 
 
-class Camera:
+class VisionInterface:
     """
-    @brief Camera wrapper using Picamera2 with a periodic vision pipeline.
+    @brief VisionInterface wrapper using Picamera2 with a periodic vision pipeline.
     @details
     Captures frames at resolution defined in ``CAMERA_RESOLUTION``, runs a detection pipeline, draws overlays,
     and exposes the last processed frame as a base64-encoded JPEG string.
@@ -21,7 +21,7 @@ class Camera:
 
     def __init__(self):
         """
-        @brief Initialize the camera and default state.
+        @brief Initialize the vision interface and default state.
         """
         self.picam2 = Picamera2()
         self.picam2.configure(
@@ -62,7 +62,7 @@ class Camera:
         """
         @brief Capture a single RGB frame as a NumPy array.
         @return RGB image (H, W, 3).
-        @note Camera must be started beforehand.
+        @note The camera must be started beforehand.
         """
         self._ensure_camera_started()
         return self.picam2.capture_array()
@@ -141,7 +141,7 @@ class Camera:
         @note Stores the last processed frame as base64 JPEG in _last_encoded_image.
         """
         if self._streaming:
-            print("[Camera] Streaming already running.")
+            print("[VisionInterface] Streaming already running.")
             return
         self._streaming = True
         self._ensure_camera_started()
@@ -161,7 +161,7 @@ class Camera:
                         with self._lock:
                             self._last_encoded_image = encoded
                 except Exception as e:
-                    print(f"[Camera] Error in periodic capture: {e}")
+                    print(f"[VisionInterface] Error in periodic capture: {e}")
 
                 # Compensate processing time to keep cadence
                 sleep_s = next_tick - time.monotonic()
@@ -173,7 +173,7 @@ class Camera:
 
         self._thread = threading.Thread(target=_capture_loop, daemon=True)
         self._thread.start()
-        print("[Camera] Started periodic capture.")
+        print("[VisionInterface] Started periodic capture.")
 
     def stop_periodic_capture(self):
         """
@@ -186,7 +186,7 @@ class Camera:
         self._ensure_camera_stopped()
         if self._logger:
             self._logger.close()
-        print("[Camera] Stopped periodic capture.")
+        print("[VisionInterface] Stopped periodic capture.")
 
     def get_last_processed_encoded(self):
         """

--- a/Server/core/vision/config_defaults.py
+++ b/Server/core/vision/config_defaults.py
@@ -1,6 +1,6 @@
 """Shared default values and thresholds for vision modules."""
 
-# Camera defaults
+# Vision interface defaults
 CAMERA_RESOLUTION = (640, 480)
 REF_SIZE = (160, 120)
 BLUR_KERNEL = 5

--- a/Server/network/ws_server.py
+++ b/Server/network/ws_server.py
@@ -4,10 +4,10 @@ import json
 import time
 import websockets
 
-from core.Camera import Camera
+from core.VisionInterface import VisionInterface
 from core.vision import api as vision_api
 
-camera = Camera()
+camera = VisionInterface()
 camera.start_periodic_capture(interval=1.0)  # sigue autoarrancando; si prefieres lazy, quita esta línea
 
 

--- a/Server/test_codes/test_visual_perception.py
+++ b/Server/test_codes/test_visual_perception.py
@@ -1,8 +1,8 @@
-from Camera import Camera
+from VisionInterface import VisionInterface
 import base64, datetime, os, time
 
 def main():
-    cam = Camera()
+    cam = VisionInterface()
     os.makedirs("logs", exist_ok=True)
     ts = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
     filename = f"logs/{ts}.jpg"


### PR DESCRIPTION
## Summary
- rename Camera module to VisionInterface
- update all imports and related references
- adjust UI text and config comment to reflect new naming

## Testing
- `python -m py_compile Client/gui/widgets/stream_widget.py Server/core/VisionInterface.py Server/core/vision/config_defaults.py Server/network/ws_server.py Server/test_codes/test_visual_perception.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'picamera2')*

------
https://chatgpt.com/codex/tasks/task_e_68b0baefc3bc832e8f9394112dec4b8e