### PR TITLE
feat: allow selecting vision detector mode

### DIFF
--- a/Server/core/vision/api.py
+++ b/Server/core/vision/api.py
@@ -34,6 +34,11 @@ def update_dynamic(which: str, params: Dict[str, Any]) -> None:
     _engine().update_dynamic(which, params)
 
 
+def select_detector(mode: str) -> None:
+    """Select detector mode."""
+    _engine().select_detector(mode)
+
+
 def process_frame(
     frame: np.ndarray,
     return_overlay: bool = True,

--- a/Server/core/vision/engine.py
+++ b/Server/core/vision/engine.py
@@ -58,6 +58,7 @@ class VisionEngine:
         self._st_big = _StableState()
         self._st_small = _StableState()
         self._last_result: Optional[EngineResult] = None
+        self._mode: str = "object"
 
     # ----------------- internal helpers -----------------
     def _knobs(self, config: Optional[Dict[str, Any]]):
@@ -128,6 +129,11 @@ class VisionEngine:
                 self._adj_big.update(**params)
             elif which == "small" and self._adj_small is not None:
                 self._adj_small.update(**params)
+
+    def select_detector(self, mode: str) -> None:
+        """Select which detector mode to use."""
+        with self._lock:
+            self._mode = mode
 
     def get_detectors(self):
         with self._lock:


### PR DESCRIPTION
## Summary
- add `select_detector` API to route mode selection to vision engine
- track detector mode in `VisionEngine` with `_mode` and `select_detector`

## Testing
- `python -m py_compile Server/core/vision/api.py Server/core/vision/engine.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'network')*


------
https://chatgpt.com/codex/tasks/task_e_68b15e80ca64832ea2ae5daf669b5615