### PR TITLE
Require explicit camera start before streaming

### DIFF
--- a/Server/core/VisionInterface.py
+++ b/Server/core/VisionInterface.py
@@ -127,12 +127,14 @@ class VisionInterface:
     # -------- Public API --------
 
     def start_stream(self, interval_sec: float = 1.0) -> None:
-        """Start periodic capture and processing in a background thread."""
+        """Start periodic capture and processing in a background thread.
+
+        The camera must be started explicitly beforehand via :meth:`start`.
+        """
         if self._streaming:
             print("[VisionInterface] Streaming already running.")
             return
         self._streaming = True
-        self.camera.start()
 
         def _capture_loop():
             period = max(0.0, float(interval_sec))

--- a/Server/test_codes/test_visual_perception.py
+++ b/Server/test_codes/test_visual_perception.py
@@ -1,5 +1,11 @@
-from VisionInterface import VisionInterface
-import base64, datetime, os, time
+import os
+import sys
+import base64, datetime, time
+
+# Ensure the Server package is on the Python path when run directly
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+from core.VisionInterface import VisionInterface
 
 def main():
     cam = VisionInterface()


### PR DESCRIPTION
## Summary
- Remove implicit camera start from `VisionInterface.start_stream` and document need for calling `start()`
- Fix visual perception test script to import from core package and ensure `start()` precedes `start_stream`

## Testing
- `pytest -q` *(fails: No module named 'network', 'gui', 'numpy', 'spidev', 'cv2', 'websockets')*

------
https://chatgpt.com/codex/tasks/task_e_68b15f7a8d98832eb7393b9cc440bac6