### PR TITLE
Log camera errors and warn when returning blank frames

### DIFF
--- a/Server/core/vision/camera.py
+++ b/Server/core/vision/camera.py
@@ -1,8 +1,14 @@
-import cv2
-import numpy as np
+"""Camera utilities for vision subsystem."""
+
+import logging
 from typing import Tuple
 
+import cv2
+import numpy as np
+
 from .config_defaults import CAMERA_RESOLUTION
+
+logger = logging.getLogger(__name__)
 
 
 class Camera:
@@ -13,12 +19,20 @@ class Camera:
         self._cap = None
 
     def start(self) -> None:
-        """Open the camera device."""
+        """Open the camera device.
+
+        Logs an error if the device cannot be opened. The camera remains
+        ``None`` when unavailable so callers can detect the condition.
+        """
         if self._cap is None:
             self._cap = cv2.VideoCapture(0)
-            if self._cap.isOpened():
-                self._cap.set(cv2.CAP_PROP_FRAME_WIDTH, self.resolution[0])
-                self._cap.set(cv2.CAP_PROP_FRAME_HEIGHT, self.resolution[1])
+            if not self._cap.isOpened():
+                logger.error("Failed to open camera device 0")
+                self._cap.release()
+                self._cap = None
+                return
+            self._cap.set(cv2.CAP_PROP_FRAME_WIDTH, self.resolution[0])
+            self._cap.set(cv2.CAP_PROP_FRAME_HEIGHT, self.resolution[1])
 
     def stop(self) -> None:
         """Release the camera device."""
@@ -27,15 +41,22 @@ class Camera:
             self._cap = None
 
     def capture_rgb(self) -> np.ndarray:
-        """Capture a single frame in RGB format."""
+        """Capture a single frame in RGB format.
+
+        When the camera is unavailable or a frame cannot be read, a blank
+        frame of the configured resolution is returned and a warning is logged.
+        This allows callers to distinguish between legitimate black frames and
+        camera errors by inspecting the logs.
+        """
         if self._cap is None:
             self.start()
         if self._cap is None or not self._cap.isOpened():
-            # Fallback to blank frame if no camera is available
+            logger.warning("Camera unavailable; returning blank frame")
             w, h = self.resolution
             return np.zeros((h, w, 3), dtype=np.uint8)
         ret, frame = self._cap.read()
         if not ret:
+            logger.warning("Failed to read frame; returning blank frame")
             w, h = self.resolution
             return np.zeros((h, w, 3), dtype=np.uint8)
         return cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)


### PR DESCRIPTION
## Summary
- log an error when the camera device cannot be opened
- warn before returning a blank frame when capture fails
- document fallback behavior for unavailable cameras

## Testing
- `python -m pytest` *(fails: ModuleNotFoundError: No module named 'network')*

------
https://chatgpt.com/codex/tasks/task_e_68b163b12c14832eac11ec737b187fd5