### PR TITLE
Expose camera running state for VisionInterface

### DIFF
--- a/Server/core/VisionInterface.py
+++ b/Server/core/VisionInterface.py
@@ -143,7 +143,7 @@ class VisionInterface:
         if self._streaming:
             print("[VisionInterface] Streaming already running.")
             return
-        if getattr(self.camera, "_cap", None) is None or not self.camera._cap.isOpened():
+        if not self.camera.is_running():
             self.camera.start()
         self._streaming = True
 

--- a/Server/core/vision/camera.py
+++ b/Server/core/vision/camera.py
@@ -54,6 +54,10 @@ class Camera:
             finally:
                 self._picam2 = None
 
+    def is_running(self) -> bool:
+        """Return ``True`` if the camera has been started."""
+        return self._picam2 is not None
+
     def capture_rgb(self) -> np.ndarray:
         """Capture a single frame in RGB format.
 


### PR DESCRIPTION
## Summary
- add `Camera.is_running` to report whether Picamera2 has been started
- update `VisionInterface.start_stream` to use the new method instead of `_cap`

## Testing
- `pytest Server/test_codes/test_visual_perception.py -q` *(fails: ModuleNotFoundError: No module named 'cv2')*


------
https://chatgpt.com/codex/tasks/task_e_68b1698a52e4832e85ad7b58d304259a