### PR TITLE
feat: add env-based vision logger factory

### DIFF
--- a/Server/core/VisionInterface.py
+++ b/Server/core/VisionInterface.py
@@ -1,15 +1,13 @@
 import base64
-import os
 import threading
 import time
 from typing import Optional
 
 import cv2
 
-from core.vision import api
+from core.vision import api, create_logger_from_env, VisionLogger
 from core.vision.camera import Camera, CameraCaptureError
 from core.vision.config_defaults import REF_SIZE
-from core.vision.viz_logger import VisionLogger
 
 
 class VisionInterface:
@@ -25,10 +23,7 @@ class VisionInterface:
         self._mode: Optional[str] = None
         self._last_error: Optional[Exception] = None
 
-        self._logger = None
-        if os.getenv("VISION_LOG", "0") == "1":
-            stride = int(os.getenv("VISION_LOG_STRIDE", "5"))
-            self._logger = VisionLogger(stride=stride, api_config={"stable": True})
+        self._logger: Optional[VisionLogger] = create_logger_from_env()
 
     # -------- Configuration API --------
 

--- a/Server/core/vision/__init__.py
+++ b/Server/core/vision/__init__.py
@@ -1,0 +1,6 @@
+"""Vision subsystem utilities."""
+
+from .viz_logger import VisionLogger, create_logger_from_env
+
+__all__ = ["VisionLogger", "create_logger_from_env"]
+

--- a/Server/core/vision/viz_logger.py
+++ b/Server/core/vision/viz_logger.py
@@ -112,6 +112,31 @@ class VisionLogger:
         try: self.csv.close()
         except: pass
 
+
+def create_logger_from_env() -> Optional["VisionLogger"]:
+    """Create a :class:`VisionLogger` from environment variables.
+
+    The function inspects the following variables:
+
+    - ``VISION_LOG``: enable logging when set to ``"1"``.
+    - ``VISION_LOG_STRIDE``: optional integer stride between logged frames.
+    - ``VISION_LOG_DIR``: optional output directory for logged artefacts.
+
+    Returns ``None`` when logging is disabled.
+    """
+
+    if os.getenv("VISION_LOG", "0") != "1":
+        return None
+
+    stride_env = os.getenv("VISION_LOG_STRIDE", "5")
+    try:
+        stride = int(stride_env)
+    except ValueError:
+        stride = 5
+
+    output_dir = os.getenv("VISION_LOG_DIR")
+    return VisionLogger(output_dir=output_dir, stride=stride, api_config={"stable": True})
+
 # Uso rápido (bucle de cámara):
 if __name__ == "__main__":
     import cv2


### PR DESCRIPTION
## Summary
- add `create_logger_from_env` helper to build `VisionLogger` from environment vars
- re-export `VisionLogger` and factory in `core.vision`
- use factory in `VisionInterface` for automatic logger setup

## Testing
- `PYTHONPATH=Server pytest -q` *(fails: ModuleNotFoundError: No module named 'network.ws_client', 'gui', 'numpy', 'spidev', 'cv2', 'websockets')*


------
https://chatgpt.com/codex/tasks/task_e_68b1c0175110832e824e027ffe1c4cdc