### PR TITLE
Streamline vision pipeline overlay and logging

### DIFF
--- a/Server/core/VisionInterface.py
+++ b/Server/core/VisionInterface.py
@@ -73,14 +73,10 @@ class VisionInterface:
     def _apply_pipeline(self):
         frame_rgb = self.camera.capture_rgb()
         frame = cv2.cvtColor(frame_rgb, cv2.COLOR_RGB2BGR)
-        try:
-            res = api.process_frame(frame, return_overlay=False, config=self._config)
-        except TypeError:
-            res = api.process_frame(frame, return_overlay=False)
+        api.process_frame(frame, return_overlay=True, config=self._config)
         if self._logger:
-            self._logger.log_only(frame, out=res)
-        result = api.get_last_result()
-        frame = draw_result(frame, result)
+            self._logger.log(frame, result=api.get_last_result())
+        frame = draw_result(frame, api.get_last_result())
         return frame
 
     # -------- Public API --------


### PR DESCRIPTION
## Summary
- Log and overlay vision results once per frame in `_apply_pipeline`
- Add tests ensuring snapshot and streaming paths process and log exactly once

## Testing
- `pytest Server/tests/test_vision_interface.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b461b28454832e939e10cb0c22dbab