### PR TITLE
Clarify get_last_result behavior

### DIFF
--- a/Server/core/vision/api.py
+++ b/Server/core/vision/api.py
@@ -57,8 +57,12 @@ def process_frame(
     return res.data
 
 
+# VisionLogger fetches the latest detection result through this helper.
 def get_last_result() -> Optional[EngineResult]:
-    """Return the last EngineResult or ``None``."""
+    """Return the most recent EngineResult produced by ``process_frame()``.
+
+    Returns ``None`` if no frame has been processed.
+    """
     return _engine().get_last_result()
 
 


### PR DESCRIPTION
## Summary
- clarify `get_last_result` docstring to reference `process_frame`
- add inline note about VisionLogger using the helper

## Testing
- `pytest -q` (fails: ModuleNotFoundError: No module named 'network')
- `pytest Server/tests/test_vision_interface.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b463cdb3cc832e87d88223cc5f5475