### PR TITLE
Add configuration module for runtime toggles

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,16 @@ Part of the code comes from the [official Freenove repository] (https://github.c
 
 ## Project status
 This project is in its early stages; documentation and code will grow as learning progresses.
+
+## Configuración
+
+La aplicación del servidor lee sus parámetros desde `Server/app/config.py`.  Allí se
+definen rutas de modelos, umbrales y claves que pueden modificarse directamente o
+mediante variables de entorno.  Ejemplos:
+
+- `VISION_ENABLE=0` desactiva el módulo de visión.
+- `MOVEMENT_ENABLE=0` desactiva el control de movimiento.
+- `VISION_PROFILE=face` cambia el perfil de detección utilizado por la cámara.
+
+También pueden ajustarse otros parámetros como `VISION_THRESHOLD` o
+`VISION_MODEL_PATH`, así como la clave `API_KEY` para servicios externos.

--- a/Server/app/application.py
+++ b/Server/app/application.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from core.VisionInterface import VisionInterface
 from core.MovementControl import MovementControl
 
+from .config import AppConfig, load_config
 from .services.vision_service import VisionService
 from .services.movement_service import MovementService
 
@@ -12,24 +13,47 @@ from .services.movement_service import MovementService
 class Application:
     """Container object wiring core interfaces with their services."""
 
-    def __init__(self) -> None:
-        self.vision = VisionInterface()
-        self.movement = MovementControl()
+    def __init__(self, config: AppConfig | None = None) -> None:
+        self.config = config or load_config()
 
-        self.vision_service = VisionService(self.vision)
-        self.movement_service = MovementService(self.movement)
+        self.vision_service: VisionService | None = None
+        if self.config.vision.enable:
+            self.vision = VisionInterface()
+            self.vision.set_mode(self.config.vision.profile)
+            self.vision.set_processing_config(
+                {
+                    "threshold": self.config.vision.threshold,
+                    "model_path": self.config.vision.model_path,
+                }
+            )
+            self.vision_service = VisionService(self.vision)
+        else:
+            self.vision = None
+
+        self.movement_service: MovementService | None = None
+        if self.config.movement.enable:
+            self.movement = MovementControl()
+            self.movement_service = MovementService(self.movement)
+        else:
+            self.movement = None
 
     def run(self) -> None:
         """Start subsystems and keep the main loop alive."""
-        self.vision_service.start()
-        self.movement_service.start()
+        if self.vision_service:
+            self.vision_service.start()
+        if self.movement_service:
+            self.movement_service.start()
 
         try:
             while True:
-                self.vision_service.update()
-                self.movement_service.update()
+                if self.vision_service:
+                    self.vision_service.update()
+                if self.movement_service:
+                    self.movement_service.update()
         except KeyboardInterrupt:
             pass
         finally:
-            self.movement_service.stop()
-            self.vision_service.stop()
+            if self.movement_service:
+                self.movement_service.stop()
+            if self.vision_service:
+                self.vision_service.stop()

--- a/Server/app/config.py
+++ b/Server/app/config.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import os
+
+
+@dataclass
+class VisionConfig:
+    """Configuration for the vision subsystem."""
+    enable: bool = True
+    profile: str = "object"  # e.g. "object" or "face"
+    threshold: float = 0.5
+    model_path: str = "models/default.pt"
+
+
+@dataclass
+class MovementConfig:
+    """Configuration for the movement subsystem."""
+    enable: bool = True
+
+
+@dataclass
+class AppConfig:
+    """Top-level application configuration."""
+    vision: VisionConfig = field(default_factory=VisionConfig)
+    movement: MovementConfig = field(default_factory=MovementConfig)
+    api_key: str = ""
+
+
+def load_config() -> AppConfig:
+    """Load configuration from environment variables."""
+    vision = VisionConfig(
+        enable=os.getenv("VISION_ENABLE", "1") == "1",
+        profile=os.getenv("VISION_PROFILE", "object"),
+        threshold=float(os.getenv("VISION_THRESHOLD", "0.5")),
+        model_path=os.getenv("VISION_MODEL_PATH", "models/default.pt"),
+    )
+    movement = MovementConfig(
+        enable=os.getenv("MOVEMENT_ENABLE", "1") == "1",
+    )
+    api_key = os.getenv("API_KEY", "")
+    return AppConfig(vision=vision, movement=movement, api_key=api_key)


### PR DESCRIPTION
## Summary
- add dataclass-based configuration loader for vision and movement parameters
- wire application to load config and enable or disable subsystems at runtime
- document configuration options in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'network')*
- `pytest Server/tests/test_vision_interface.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5b5e849f8832e9236272caf3052f3