### PR TITLE
Add stream start/stop commands to robot controller

### DIFF
--- a/Server/app/controllers/robot_controller.py
+++ b/Server/app/controllers/robot_controller.py
@@ -40,6 +40,15 @@ class RobotController:
             self._vision.stop()
             return {"status": "ok", "type": "text", "data": "capture stopped"}
 
+        if cmd == "stream_start":
+            # start the vision streaming generator
+            self._vision.stream()
+            return {"status": "ok", "type": "text", "data": "streaming started"}
+
+        if cmd == "stream_stop":
+            self._vision.stop()
+            return {"status": "ok", "type": "text", "data": "streaming stopped"}
+
         if cmd == "capture":
             img_str = await self._wait_for_frame(timeout=float(data.get("timeout", 2.0)))
             if img_str is None:

--- a/Server/app/services/vision_service.py
+++ b/Server/app/services/vision_service.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 """Orchestration helpers for the vision subsystem."""
 
+import time
+from typing import Generator, Optional
+
 from core.VisionInterface import VisionInterface
 
 
@@ -27,6 +30,15 @@ class VisionService:
     def get_last_processed_encoded(self):
         """Expose last processed frame."""
         return self._vision.get_last_processed_encoded()
+
+    def stream(self) -> Generator[Optional[str], None, None]:
+        """Yield processed frames as they become available."""
+        # ensure underlying vision subsystem is streaming
+        if not getattr(self._vision, "_streaming", False):
+            self._vision.start_stream()
+        while getattr(self._vision, "_streaming", False):
+            yield self._vision.get_last_processed_encoded()
+            time.sleep(0.05)
 
     def set_processing_config(self, config: dict) -> None:
         """Forward runtime processing configuration."""


### PR DESCRIPTION
## Summary
- handle new `stream_start` and `stream_stop` commands in `RobotController`
- expose a `VisionService.stream` generator for streaming frames

## Testing
- `pytest tests/client/network/test_ws_command.py -q` *(fails: No module named 'websockets')*
- `pytest tests/client/network/test_ws_img_stream.py -q` *(fails: No module named 'PyQt6')*


------
https://chatgpt.com/codex/tasks/task_e_68b5f563d624832e9f4ff2f97d419ce9