### PR TITLE
feat: add vision stream interval config

### DIFF
--- a/Server/app/config.py
+++ b/Server/app/config.py
@@ -9,6 +9,7 @@ import tomllib
 class VisionConfig:
     """Configuration for the vision subsystem."""
     enable: bool = True
+    stream_interval: float = 0.2
     profile: str = "object"  # e.g. "object" or "face"
     threshold: float = 0.5
     model_path: str = "models/default.pt"
@@ -52,6 +53,9 @@ def load_config() -> AppConfig:
     vision_data = data.get("vision", {})
     vision = VisionConfig(
         enable=vision_data.get("enable", vision_defaults.enable),
+        stream_interval=vision_data.get(
+            "stream_interval", vision_defaults.stream_interval
+        ),
         profile=vision_data.get("profile", vision_defaults.profile),
         threshold=vision_data.get("threshold", vision_defaults.threshold),
         model_path=vision_data.get("model_path", vision_defaults.model_path),

--- a/Server/app/config.toml
+++ b/Server/app/config.toml
@@ -1,5 +1,6 @@
 [vision]
 enable = true
+stream_interval = 0.2
 profile = "object"
 threshold = 0.5
 model_path = "models/default.pt"

--- a/Server/app/services/vision_service.py
+++ b/Server/app/services/vision_service.py
@@ -31,14 +31,14 @@ class VisionService:
         """Expose last processed frame."""
         return self._vision.get_last_processed_encoded()
 
-    def stream(self) -> Generator[Optional[str], None, None]:
+    def stream(self, interval_sec: float = 0.05) -> Generator[Optional[str], None, None]:
         """Yield processed frames as they become available."""
         # ensure underlying vision subsystem is streaming
         if not getattr(self._vision, "_streaming", False):
-            self._vision.start_stream()
+            self._vision.start_stream(interval_sec=interval_sec)
         while getattr(self._vision, "_streaming", False):
             yield self._vision.get_last_processed_encoded()
-            time.sleep(0.05)
+            time.sleep(interval_sec)
 
     def set_processing_config(self, config: dict) -> None:
         """Forward runtime processing configuration."""

--- a/Server/network/ws_server.py
+++ b/Server/network/ws_server.py
@@ -29,13 +29,15 @@ async def _vision_stream(websocket: websockets.WebSocketServerProtocol) -> None:
     """Continuously push vision frames to a websocket client."""
     interval = getattr(getattr(_app.config, "vision", _app.config), "stream_interval", 0.0)
     try:
-        stream = _controller._vision.stream() if _controller._vision else iter(())
+        stream = (
+            _controller._vision.stream(interval_sec=interval)
+            if _controller._vision
+            else iter(())
+        )
         while websocket in _streaming_clients:
             frame = next(stream, None)
             if frame:
                 await websocket.send(json.dumps({"type": "image", "data": frame}))
-            if interval:
-                await asyncio.sleep(float(interval))
     except websockets.ConnectionClosed:
         pass
     finally:


### PR DESCRIPTION
## Summary
- extend vision config with `stream_interval` setting and read it from `config.toml`
- allow `VisionService.stream` to accept an interval and use it to drive streaming
- wire websocket vision streaming to use configured interval

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'websockets')*


------
https://chatgpt.com/codex/tasks/task_e_68b5fba95348832eba7bab73941295f9