### PR TITLE
Use streaming callback for GUI image updates

### DIFF
--- a/Client/gui/main_window.py
+++ b/Client/gui/main_window.py
@@ -18,6 +18,10 @@ class ImageStreamViewer(QMainWindow):
 
         self.setCentralWidget(widget)
 
+    def closeEvent(self, event):
+        self.ws_client.stop_stream()
+        super().closeEvent(event)
+
 def start_gui():
     app = QApplication(sys.argv)
     window = ImageStreamViewer()


### PR DESCRIPTION
## Summary
- Replace timer-based capture with WebSocket streaming callback
- Display incoming frames and stop stream on window close

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'websockets'; No module named 'PyQt6'; No module named 'numpy'; No module named 'spidev'; No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_68b606e1ad20832e81522b7eed5a266a