### PR TITLE
Use real WebSocket client for image stream test

### DIFF
--- a/tests/client/network/test_ws_stream.py
+++ b/tests/client/network/test_ws_stream.py
@@ -1,73 +1,54 @@
+"""Simple script for testing the WebSocket image stream.
+
+Run this file directly to connect to the server, receive base64 encoded
+frames, decode them and display the resulting images using OpenCV.
+The stream continues until the user presses the ESC key or closes the
+window.
+"""
+
+import base64
 import sys
-import types
-import asyncio
-import json
-import threading
 import time
 from pathlib import Path
 
-import pytest
-
-# Stub websockets module
-class FakeWebSocket:
-    def __init__(self):
-        self.queue = asyncio.Queue()
-        self.sent = []
-
-    async def send(self, message):
-        data = json.loads(message)
-        self.sent.append(data)
-        if data.get("cmd") == "stream_start":
-            await self.queue.put(json.dumps({"type": "image", "frame": "frame"}))
-
-    async def recv(self):
-        return await self.queue.get()
-
-    def __aiter__(self):
-        return self
-
-    async def __anext__(self):
-        return await self.queue.get()
-
-    async def close(self):
-        pass
-
-fake_ws_holder = {}
-
-async def fake_connect(uri):
-    ws = FakeWebSocket()
-    fake_ws_holder["ws"] = ws
-    return ws
-
-sys.modules['websockets'] = types.SimpleNamespace(connect=fake_connect)
-
 ROOT = Path(__file__).resolve().parents[3] / "Client"
 sys.path.insert(0, str(ROOT))
-from network.ws_client import WebSocketClient
 
 
-def test_start_and_stop_stream():
+def main() -> None:
+    """Connect to the server and display the streamed frames."""
+
+    from network.ws_client import WebSocketClient
+    import cv2  # Imported here to avoid dependency during test collection
+    import numpy as np
+
     client = WebSocketClient()
-    client.uri = "ws://test"
-    frames = []
-    evt = threading.Event()
 
-    def callback(frame):
-        frames.append(frame)
-        evt.set()
+    def on_frame(base64_frame: str) -> None:
+        img_bytes = base64.b64decode(base64_frame)
+        img_array = np.frombuffer(img_bytes, np.uint8)
+        frame = cv2.imdecode(img_array, cv2.IMREAD_COLOR)
+        if frame is not None:
+            cv2.imshow("WebSocket Stream", frame)
 
-    client.start_stream(callback)
-    assert evt.wait(1)
-    assert frames == ["frame"]
-    evt.clear()
+    client.start_stream(on_frame)
 
-    client.stop_stream()
+    try:
+        while True:
+            # Exit if ESC pressed or the window has been closed.
+            if cv2.waitKey(1) & 0xFF == 27:
+                break
+            if cv2.getWindowProperty("WebSocket Stream", cv2.WND_PROP_VISIBLE) < 1:
+                break
+            time.sleep(0.01)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        client.stop_stream()
+        client.close()
+        cv2.destroyAllWindows()
 
-    ws = fake_ws_holder["ws"]
-    asyncio.run_coroutine_threadsafe(ws.queue.put(json.dumps({"type": "image", "frame": "after"})), client.loop)
-    time.sleep(0.1)
-    assert not evt.is_set()
-    assert client.receive_task is None
-    assert any(cmd.get("cmd") == "stream_start" for cmd in ws.sent)
-    assert any(cmd.get("cmd") == "stream_stop" for cmd in ws.sent)
-    client.close()
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- Replace stubbed WebSocket test with real `WebSocketClient` usage
- Decode and display streamed frames with OpenCV
- Keep script alive until ESC or window close and cleanup

## Testing
- `pytest tests/client/network/test_ws_stream.py -q`
- `python tests/client/network/test_ws_stream.py` *(fails: ModuleNotFoundError: No module named 'websockets')*


------
https://chatgpt.com/codex/tasks/task_e_68b60f8e7f70832eba2df5b01e8e5aa8