### PR TITLE
Add voice, LED, and hearing config

### DIFF
--- a/Server/app/config.py
+++ b/Server/app/config.py
@@ -22,6 +22,27 @@ class MovementConfig:
 
 
 @dataclass
+class VoiceConfig:
+    """Configuration for the voice subsystem."""
+
+    enable: bool = True
+
+
+@dataclass
+class LedConfig:
+    """Configuration for the LED subsystem."""
+
+    enable: bool = True
+
+
+@dataclass
+class HearingConfig:
+    """Configuration for the hearing subsystem."""
+
+    enable: bool = True
+
+
+@dataclass
 class LoggingConfig:
     """Global logging configuration."""
 
@@ -29,6 +50,9 @@ class LoggingConfig:
     level: str = "INFO"
     vision: bool = True
     movement: bool = False
+    voice: bool = False
+    led: bool = False
+    hearing: bool = False
 
 
 @dataclass
@@ -36,6 +60,9 @@ class AppConfig:
     """Top-level application configuration."""
     vision: VisionConfig = field(default_factory=VisionConfig)
     movement: MovementConfig = field(default_factory=MovementConfig)
+    voice: VoiceConfig = field(default_factory=VoiceConfig)
+    led: LedConfig = field(default_factory=LedConfig)
+    hearing: HearingConfig = field(default_factory=HearingConfig)
     logging: LoggingConfig = field(default_factory=LoggingConfig)
     api_key: str = ""
 
@@ -67,6 +94,24 @@ def load_config() -> AppConfig:
         enable=movement_data.get("enable", movement_defaults.enable),
     )
 
+    voice_defaults = VoiceConfig()
+    voice_data = data.get("voice", {})
+    voice = VoiceConfig(
+        enable=voice_data.get("enable", voice_defaults.enable),
+    )
+
+    led_defaults = LedConfig()
+    led_data = data.get("led", {})
+    led = LedConfig(
+        enable=led_data.get("enable", led_defaults.enable),
+    )
+
+    hearing_defaults = HearingConfig()
+    hearing_data = data.get("hearing", {})
+    hearing = HearingConfig(
+        enable=hearing_data.get("enable", hearing_defaults.enable),
+    )
+
     logging_defaults = LoggingConfig()
     logging_data = data.get("logging", {})
     logging_cfg = LoggingConfig(
@@ -74,6 +119,9 @@ def load_config() -> AppConfig:
         level=logging_data.get("level", logging_defaults.level),
         vision=vision_data.get("log", logging_defaults.vision),
         movement=movement_data.get("log", logging_defaults.movement),
+        voice=voice_data.get("log", logging_defaults.voice),
+        led=led_data.get("log", logging_defaults.led),
+        hearing=hearing_data.get("log", logging_defaults.hearing),
     )
 
     api_key = data.get("api_key", "")
@@ -81,6 +129,9 @@ def load_config() -> AppConfig:
     return AppConfig(
         vision=vision,
         movement=movement,
+        voice=voice,
+        led=led,
+        hearing=hearing,
         logging=logging_cfg,
         api_key=api_key,
     )

--- a/Server/app/config.toml
+++ b/Server/app/config.toml
@@ -10,5 +10,17 @@ log = true     # vision-specific logging
 enable = true
 log = false
 
+[voice]
+enable = true
+log = false
+
+[led]
+enable = true
+log = false
+
+[hearing]
+enable = true
+log = false
+
 [logging]
 level = "INFO" # global log level

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -16,10 +16,23 @@ log = true
 enable = true
 log = false
 
+[voice]
+enable = true
+log = false
+
+[led]
+enable = true
+log = false
+
+[hearing]
+enable = true
+log = false
+
 [logging]
 level = "INFO"
 ```
 
 `Server/run.py` simply loads this file on start-up and no longer requires
 command-line arguments or environment variables. Adjust the values in the TOML
-file to change behaviour or logging preferences.
+file to enable subsystems like voice, LED, or hearing and tune their logging
+preferences alongside vision and movement.


### PR DESCRIPTION
## Summary
- add `[voice]`, `[led]`, and `[hearing]` sections with `enable` and optional `log` flags
- create `VoiceConfig`, `LedConfig`, and `HearingConfig` dataclasses and wire them into `AppConfig`
- document new configuration options in `docs/overview.md`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'websockets'; ModuleNotFoundError: No module named 'PyQt6'; ModuleNotFoundError: No module named 'numpy'; ModuleNotFoundError: No module named 'spidev')*

------
https://chatgpt.com/codex/tasks/task_e_68b61da43188832e86b809c18bc2853b