### PR TITLE
feat: add logging-aware service wrappers

### DIFF
--- a/Server/app/application.py
+++ b/Server/app/application.py
@@ -10,11 +10,13 @@ from core.vision.viz_logger import create_logger as create_vision_logger
 from core.movement.logger import MovementLogger
 
 from .config import AppConfig, load_config
-from .services.vision_service import VisionService
-from .services.movement_service import MovementService
-from .services.voice_service import VoiceService
-from .services.led_service import LedService
-from .services.hearing_service import HearingService
+from .services import (
+    VisionService,
+    MovementService,
+    VoiceService,
+    LedService,
+    HearingService,
+)
 
 
 class Application:
@@ -39,7 +41,9 @@ class Application:
                     "model_path": self.config.vision.model_path,
                 }
             )
-            self.vision_service = VisionService(self.vision)
+            self.vision_service = VisionService(
+                self.vision, enable_logging=self.config.logging.vision
+            )
         else:
             self.vision = None
 
@@ -47,7 +51,9 @@ class Application:
         if self.config.movement.enable:
             mv_logger = MovementLogger() if self.config.logging.movement else None
             self.movement = MovementControl(logger=mv_logger)
-            self.movement_service = MovementService(self.movement)
+            self.movement_service = MovementService(
+                self.movement, enable_logging=self.config.logging.movement
+            )
         else:
             self.movement = None
 
@@ -57,7 +63,9 @@ class Application:
                 from core.VoiceInterface import ConversationManager
 
                 self.voice = ConversationManager()
-                self.voice_service = VoiceService(self.voice)
+                self.voice_service = VoiceService(
+                    self.voice, enable_logging=self.config.logging.voice
+                )
             except Exception as exc:  # pragma: no cover - best effort
                 logging.getLogger(__name__).warning(
                     "Voice subsystem unavailable: %s", exc
@@ -72,7 +80,9 @@ class Application:
                 from core.LedController import LedController
 
                 self.led = LedController()
-                self.led_service = LedService(self.led)
+                self.led_service = LedService(
+                    self.led, enable_logging=self.config.logging.led
+                )
             except Exception as exc:  # pragma: no cover
                 logging.getLogger(__name__).warning(
                     "LED subsystem unavailable: %s", exc
@@ -87,7 +97,9 @@ class Application:
                 from core.hearing.stt import SpeechToText
 
                 self.hearing = SpeechToText()
-                self.hearing_service = HearingService(self.hearing)
+                self.hearing_service = HearingService(
+                    self.hearing, enable_logging=self.config.logging.hearing
+                )
             except Exception as exc:  # pragma: no cover
                 logging.getLogger(__name__).warning(
                     "Hearing subsystem unavailable: %s", exc

--- a/Server/app/services/__init__.py
+++ b/Server/app/services/__init__.py
@@ -1,0 +1,16 @@
+"""Service layer exports for easy importing."""
+
+from .vision_service import VisionService
+from .movement_service import MovementService
+from .voice_service import VoiceService
+from .led_service import LedService
+from .hearing_service import HearingService
+
+__all__ = [
+    "VisionService",
+    "MovementService",
+    "VoiceService",
+    "LedService",
+    "HearingService",
+]
+

--- a/Server/app/services/hearing_service.py
+++ b/Server/app/services/hearing_service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 """Orchestration helpers for the hearing subsystem."""
 
+import logging
 import threading
 from typing import TYPE_CHECKING
 
@@ -12,16 +13,19 @@ if TYPE_CHECKING:  # pragma: no cover
 class HearingService:
     """Thin wrapper around :class:`SpeechToText`."""
 
-    def __init__(self, stt: "SpeechToText") -> None:
+    def __init__(self, stt: "SpeechToText", *, enable_logging: bool = False) -> None:
         self._stt = stt
         self._thread: threading.Thread | None = None
         self._running = False
+        self._log = logging.getLogger(__name__) if enable_logging else None
 
     def start(self) -> None:
         """Start background listening (discovers phrases but discards them)."""
         if self._running:
             return
         self._running = True
+        if self._log:
+            self._log.debug("Starting hearing service")
 
         def _drain() -> None:
             try:
@@ -41,5 +45,7 @@ class HearingService:
     def stop(self) -> None:
         """Stop background listening."""
         self._running = False
+        if self._log:
+            self._log.debug("Stopping hearing service")
         if self._thread and self._thread.is_alive():
             self._thread.join(timeout=0.1)

--- a/Server/app/services/led_service.py
+++ b/Server/app/services/led_service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 """Orchestration helpers for the LED subsystem."""
 
 import asyncio
+import logging
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -12,11 +13,16 @@ if TYPE_CHECKING:  # pragma: no cover
 class LedService:
     """Service wrapper around :class:`LedController`."""
 
-    def __init__(self, controller: "LedController") -> None:
+    def __init__(
+        self, controller: "LedController", *, enable_logging: bool = False
+    ) -> None:
         self._controller = controller
+        self._log = logging.getLogger(__name__) if enable_logging else None
 
     def start(self) -> None:
         """Initialize the LED subsystem (no-op)."""
+        if self._log:
+            self._log.debug("Starting LED service")
         return None
 
     def update(self) -> None:
@@ -25,6 +31,8 @@ class LedService:
 
     def stop(self) -> None:
         """Close the LED controller and release resources."""
+        if self._log:
+            self._log.debug("Stopping LED service")
         try:
             asyncio.run(self._controller.close())
         except Exception:

--- a/Server/app/services/movement_service.py
+++ b/Server/app/services/movement_service.py
@@ -2,17 +2,23 @@ from __future__ import annotations
 
 """Orchestration helpers for the movement subsystem."""
 
+import logging
 from core.MovementControl import MovementControl
 
 
 class MovementService:
     """Dispatch high-level commands to :class:`MovementControl`."""
 
-    def __init__(self, controller: MovementControl) -> None:
+    def __init__(
+        self, controller: MovementControl, *, enable_logging: bool = False
+    ) -> None:
         self._controller = controller
+        self._log = logging.getLogger(__name__) if enable_logging else None
 
     def start(self) -> None:
         """Initialize the movement controller."""
+        if self._log:
+            self._log.debug("Starting movement service")
         # No explicit start sequence required; placeholder for future use.
         return None
 
@@ -22,6 +28,8 @@ class MovementService:
 
     def stop(self) -> None:
         """Stop any ongoing motion."""
+        if self._log:
+            self._log.debug("Stopping movement service")
         try:
             self._controller.stop()
         except Exception:

--- a/Server/app/services/vision_service.py
+++ b/Server/app/services/vision_service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 """Orchestration helpers for the vision subsystem."""
 
+import logging
 import time
 from typing import Generator, Optional
 
@@ -11,12 +12,15 @@ from core.VisionInterface import VisionInterface
 class VisionService:
     """Thin wrapper around :class:`VisionInterface`."""
 
-    def __init__(self, vision: VisionInterface) -> None:
+    def __init__(self, vision: VisionInterface, *, enable_logging: bool = False) -> None:
         self._vision = vision
+        self._log = logging.getLogger(__name__) if enable_logging else None
 
     def start(self, interval_sec: float = 1.0) -> None:
         """Begin periodic capture with optional interval."""
         # Start background streaming to continually process frames.
+        if self._log:
+            self._log.debug("Starting vision service")
         self._vision.start_stream(interval_sec=interval_sec)
 
     def update(self) -> None:
@@ -25,6 +29,8 @@ class VisionService:
 
     def stop(self) -> None:
         """Stop any active streaming and release resources."""
+        if self._log:
+            self._log.debug("Stopping vision service")
         self._vision.stop()
 
     def get_last_processed_encoded(self):

--- a/Server/app/services/voice_service.py
+++ b/Server/app/services/voice_service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 """Orchestration helpers for the voice subsystem."""
 
+import logging
 import threading
 from typing import TYPE_CHECKING
 
@@ -12,12 +13,17 @@ if TYPE_CHECKING:  # pragma: no cover - for type hints only
 class VoiceService:
     """Thin wrapper around :class:`ConversationManager`."""
 
-    def __init__(self, interface: "ConversationManager") -> None:
+    def __init__(
+        self, interface: "ConversationManager", *, enable_logging: bool = False
+    ) -> None:
         self._interface = interface
         self._thread: threading.Thread | None = None
+        self._log = logging.getLogger(__name__) if enable_logging else None
 
     def start(self) -> None:
         """Launch the conversation manager in a background thread."""
+        if self._log:
+            self._log.debug("Starting voice service")
         if self._thread and self._thread.is_alive():
             return
         self._thread = threading.Thread(target=self._interface.run, daemon=True)
@@ -29,6 +35,8 @@ class VoiceService:
 
     def stop(self) -> None:
         """Stop the conversation manager if running."""
+        if self._log:
+            self._log.debug("Stopping voice service")
         # The underlying conversation loop has no explicit shutdown, so this
         # merely signals the thread to end when the loop finishes.
         return None


### PR DESCRIPTION
## Summary
- add logging flag support to voice, LED, hearing, movement, and vision services
- export service classes from `app.services` for simpler imports
- wire application to pass logging configuration to each service

## Testing
- `python -m py_compile Server/app/services/voice_service.py Server/app/services/led_service.py Server/app/services/hearing_service.py Server/app/services/movement_service.py Server/app/services/vision_service.py Server/app/services/__init__.py Server/app/application.py`
- `pytest -q` *(fails: ModuleNotFoundError for websockets, PyQt6, numpy, spidev)*

------
https://chatgpt.com/codex/tasks/task_e_68b692562b00832e99ad1e91b7ed765f