### PR TITLE
feat: configure logging flags per subsystem

### DIFF
--- a/Server/app/config.py
+++ b/Server/app/config.py
@@ -117,11 +117,11 @@ def load_config() -> AppConfig:
     logging_cfg = LoggingConfig(
         enable=logging_data.get("enable", logging_defaults.enable),
         level=logging_data.get("level", logging_defaults.level),
-        vision=vision_data.get("log", logging_defaults.vision),
-        movement=movement_data.get("log", logging_defaults.movement),
-        voice=voice_data.get("log", logging_defaults.voice),
-        led=led_data.get("log", logging_defaults.led),
-        hearing=hearing_data.get("log", logging_defaults.hearing),
+        vision=logging_data.get("vision", logging_defaults.vision),
+        movement=logging_data.get("movement", logging_defaults.movement),
+        voice=logging_data.get("voice", logging_defaults.voice),
+        led=logging_data.get("led", logging_defaults.led),
+        hearing=logging_data.get("hearing", logging_defaults.hearing),
     )
 
     api_key = data.get("api_key", "")

--- a/Server/app/config.toml
+++ b/Server/app/config.toml
@@ -4,23 +4,24 @@ stream_interval = 0.2
 profile = "object"
 threshold = 0.5
 model_path = "models/default.pt"
-log = true     # vision-specific logging
 
 [movement]
 enable = true
-log = false
 
 [voice]
 enable = true
-log = false
 
 [led]
 enable = true
-log = false
 
 [hearing]
 enable = true
-log = false
 
 [logging]
+enable = true
 level = "INFO" # global log level
+vision = true
+movement = false
+voice = false
+led = false
+hearing = false


### PR DESCRIPTION
## Summary
- add toggles for voice, LED and hearing logs in global LoggingConfig
- wire log toggles through configuration loader
- provide default subsystem logging flags in config.toml

## Testing
- `pytest` *(fails: No module named 'websockets'; No module named 'PyQt6'; No module named 'numpy'; No module named 'spidev'; AttributeError 'types.SimpleNamespace' object has no attribute 'ndarray'; TypeError unsupported operand type(s) for >>: '_NPArray' and 'int')*

------
https://chatgpt.com/codex/tasks/task_e_68b6968891e0832e9d9a208b97af3997