### PR TITLE
Refactor server package initialization

### DIFF
--- a/Server/__init__.py
+++ b/Server/__init__.py
@@ -1,0 +1,1 @@
+"""Server package."""

--- a/Server/run.py
+++ b/Server/run.py
@@ -1,17 +1,4 @@
-import os
-import sys
-
-project_root = os.path.dirname(os.path.abspath(__file__))
-
-if project_root not in sys.path:
-    sys.path.insert(0, project_root)
-
-for folder in ["core", "lib", "test_codes", "network"]:
-    folder_path = os.path.join(project_root, folder)
-    if folder_path not in sys.path:
-        sys.path.insert(0, folder_path)
-
-from app.application import Application
+from Server.app.application import Application
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- add module docstring to `Server` package
- remove manual `sys.path` hacking in `Server/run.py`
- use absolute import `from Server.app.application import Application`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'websockets'; ModuleNotFoundError: No module named 'PyQt6'; ModuleNotFoundError: No module named 'numpy'; ModuleNotFoundError: No module named 'spidev')*

------
https://chatgpt.com/codex/tasks/task_e_68b6979f55d0832ea8d4781da4f09f70