### PR TITLE
Remove dynamic vision processing configuration

### DIFF
--- a/Server/app/services/vision_service.py
+++ b/Server/app/services/vision_service.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Optional, Dict, Any
+from typing import Optional
 
 from core.VisionInterface import VisionInterface
 
@@ -25,8 +25,3 @@ class VisionService:
     def snapshot_b64(self) -> Optional[str]:
         return self.vi.snapshot()
 
-    def set_processing(self, cfg: Dict[str, Any]) -> None:
-        allowed = {"blur", "edges", "contours", "ref_size"}
-        filtered = {k: v for k, v in (cfg or {}).items() if k in allowed}
-        if filtered:
-            self.vi.set_processing_config(filtered)

--- a/Server/core/VisionInterface.py
+++ b/Server/core/VisionInterface.py
@@ -23,7 +23,6 @@ class VisionInterface:
         logger: Optional['VisionLogger'] = None,
     ) -> None:
         self.camera = camera or Camera(max_failures=max_capture_failures)
-        self._config: dict = {}
         self._last_encoded_image: Optional[str] = None
         self._streaming = False
         self._thread: Optional[threading.Thread] = None
@@ -34,10 +33,6 @@ class VisionInterface:
         self._logger: Optional['VisionLogger'] = logger or api.create_logger_from_env()
 
     # -------- Configuration API --------
-
-    def set_processing_config(self, cfg: dict) -> None:
-        """Store runtime configuration for the processing pipeline."""
-        self._config = dict(cfg or {})
 
     def set_mode(self, mode: str) -> None:
         """Select detection mode: ``"object"`` or ``"face"``."""
@@ -73,7 +68,7 @@ class VisionInterface:
     def _apply_pipeline(self):
         frame_rgb = self.camera.capture_rgb()
         frame = cv2.cvtColor(frame_rgb, cv2.COLOR_RGB2BGR)
-        api.process_frame(frame, return_overlay=True, config=self._config)
+        api.process_frame(frame, return_overlay=True)
         if self._logger:
             self._logger.log(frame, result=api.get_last_result())
         frame = draw_result(frame, api.get_last_result())

--- a/Server/network/ws_server.py
+++ b/Server/network/ws_server.py
@@ -44,9 +44,6 @@ def make_handler(svc: VisionService) -> Callable:
                     resp = {"status": "ok" if img else "wait",
                             "type": "image" if img else "text",
                             "data": img or "no frame yet"}
-                elif cmd == "process":
-                    svc.set_processing(data)
-                    resp = {"status": "ok", "type": "text", "data": "processing updated"}
                 else:
                     resp = {"status": "error", "type": "text", "data": f"unknown command: {cmd}"}
 


### PR DESCRIPTION
## Summary
- remove websocket "process" command and its handling
- drop VisionService.set_processing and config plumbing
- simplify VisionInterface to process frames without external config

## Testing
- `pytest -q` *(fails: No module named 'network', 'gui', 'numpy', 'spidev', 'cv2')*


------
https://chatgpt.com/codex/tasks/task_e_68b6d1567b3c832e81367e9507b9107d