### PR TITLE
Add generic detector base and extract DetectionResult

### DIFF
--- a/Server/core/vision/detectors/README.md
+++ b/Server/core/vision/detectors/README.md
@@ -25,7 +25,7 @@ Resumen conciso del pipeline y tuning. Paridad con `contour_detector.py` y `api.
 ```python
 from core.vision.detectors.contour_detector import ContourDetector
 det = ContourDetector.from_profile("profile_big_solid.json")
-res = det.detect(frame_bgr, return_overlay=True)
+res = det.detect(frame_bgr, knobs={"return_overlay": True})
 
 from core.vision.api import process_frame
 out = process_frame(frame_bgr, return_overlay=True, config={"roi_factor":1.8, "ema":0.7})

--- a/Server/core/vision/detectors/base_detector.py
+++ b/Server/core/vision/detectors/base_detector.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict, Optional
+from numpy.typing import NDArray
+
+from .results import DetectionResult
+
+
+class BaseDetector(ABC):
+    """Abstract interface for vision detectors."""
+
+    @abstractmethod
+    def detect(
+        self,
+        frame: NDArray,
+        state: Optional[Dict[str, Any]] = None,
+        knobs: Optional[Dict[str, Any]] = None,
+    ) -> DetectionResult:
+        """Run detection on *frame*.
+
+        Args:
+            frame: Image frame in BGR color space.
+            state: Mutable state carried between calls.
+            knobs: Runtime configuration overrides.
+
+        Returns:
+            DetectionResult: Outcome of the detector.
+        """
+        raise NotImplementedError

--- a/Server/core/vision/detectors/face_detector.py
+++ b/Server/core/vision/detectors/face_detector.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+from numpy.typing import NDArray
+
+from .base_detector import BaseDetector
+from .results import DetectionResult
+
+
+class FaceDetector(BaseDetector):
+    """Example stub detector implementing :class:`BaseDetector`."""
+
+    def detect(
+        self,
+        frame: NDArray,
+        state: Optional[Dict[str, Any]] = None,
+        knobs: Optional[Dict[str, Any]] = None,
+    ) -> DetectionResult:
+        """Dummy implementation returning a negative result."""
+        return DetectionResult(ok=False)

--- a/Server/core/vision/detectors/results.py
+++ b/Server/core/vision/detectors/results.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Tuple
+from numpy.typing import NDArray
+
+
+@dataclass
+class DetectionResult:
+    """Generic detection output returned by detectors.
+
+    Attributes:
+        ok: Whether a valid detection was found.
+        bbox: Bounding box ``(x, y, w, h)`` in pixels.
+        score: Optional score describing detection confidence.
+        center: Optional center point ``(x, y)``.
+        overlay: Optional visualization image.
+        fill: Percent fill of contour (contour detectors).
+        bbox_ratio: Aspect ratio of bounding box (contour detectors).
+        used_rescue: Whether rescue thresholding was used.
+        life_canny_pct: Life percentage from the dynamic adjuster.
+        chosen_ck: Closing kernel size chosen.
+        chosen_dk: Dilation kernel size chosen.
+        t1: Low Canny threshold chosen.
+        t2: High Canny threshold chosen.
+        color_cover_pct: Percent of color mask coverage.
+        color_used: Whether the color gate was applied.
+    """
+
+    ok: bool
+    bbox: Optional[Tuple[int, int, int, int]] = None
+    score: Optional[float] = None
+    center: Optional[Tuple[int, int]] = None
+    overlay: Optional[NDArray] = None
+
+    # Contour-specific optional fields
+    fill: Optional[float] = None
+    bbox_ratio: Optional[float] = None
+    used_rescue: Optional[bool] = None
+    life_canny_pct: Optional[float] = None
+    chosen_ck: Optional[int] = None
+    chosen_dk: Optional[int] = None
+    t1: Optional[float] = None
+    t2: Optional[int] = None
+    color_cover_pct: Optional[float] = None
+    color_used: Optional[bool] = None


### PR DESCRIPTION
## Summary
- introduce a common `BaseDetector` interface and shared `DetectionResult` dataclass
- adjust `ContourDetector` to new `detect(frame, state, knobs)` signature
- add stub `FaceDetector` and adapt pipeline to new results module

## Testing
- `pytest` *(fails: No module named 'network', 'gui', 'spidev', 'cv2', 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68b713abe368832e95c33c3f4ee5e69c