### PR TITLE
refactor: rename vision interface to VisionManager

### DIFF
--- a/Server/app/services/vision_service.py
+++ b/Server/app/services/vision_service.py
@@ -1,26 +1,27 @@
 from __future__ import annotations
 from typing import Optional
 
-from core.VisionInterface import VisionInterface
+from core.vision.VisionManager import VisionManager
 
 class VisionService:
-    def __init__(self, vi: Optional[VisionInterface] = None) -> None:
-        self.vi = vi or VisionInterface()
+    def __init__(self, vm: Optional[VisionManager] = None) -> None:
+        self.vm = vm or VisionManager()
         self._running = False
 
     def start(self, interval_sec: float = 1.0) -> None:
         if not self._running:
-            self.vi.start()
-            self.vi.start_stream(interval_sec=interval_sec)
+            self.vm.start()
+            self.vm.start_stream(interval_sec=interval_sec)
             self._running = True
 
     def stop(self) -> None:
         if self._running:
-            self.vi.stop()
+            self.vm.stop()
             self._running = False
 
     def last_b64(self) -> Optional[str]:
-        return self.vi.get_last_processed_encoded()
+        return self.vm.get_last_processed_encoded()
 
     def snapshot_b64(self) -> Optional[str]:
-        return self.vi.snapshot()
+        return self.vm.snapshot()
+

--- a/Server/core/vision/VisionManager.py
+++ b/Server/core/vision/VisionManager.py
@@ -5,16 +5,16 @@ from typing import Optional, TYPE_CHECKING
 
 import cv2
 
-from core.vision import api
-from core.vision.camera import Camera, CameraCaptureError
-from core.vision.overlays import draw_result
+from . import api
+from .camera import Camera, CameraCaptureError
+from .overlays import draw_result
 
-if TYPE_CHECKING:
-    from core.vision.viz_logger import VisionLogger
+if TYPE_CHECKING:  # pragma: no cover - for type checkers only
+    from .viz_logger import VisionLogger
 
 
-class VisionInterface:
-    """Vision interface backed by :class:`Camera` and vision ``api``."""
+class VisionManager:
+    """High-level vision manager backed by :class:`Camera` and vision ``api``."""
 
     def __init__(
         self,
@@ -34,12 +34,18 @@ class VisionInterface:
 
     # -------- Configuration API --------
 
-    def set_mode(self, mode: str) -> None:
-        """Select detection mode: ``"object"`` or ``"face"``."""
-        if mode not in {"object", "face"}:
-            raise ValueError("mode must be 'object' or 'face'")
-        self._mode = mode
-        api.select_detector(mode)
+    def register_pipeline(self, name: str, pipeline) -> None:
+        """Register a new vision ``pipeline`` under ``name``."""
+        api.register_pipeline(name, pipeline)
+
+    def select_pipeline(self, name: str) -> None:
+        """Select the active vision pipeline by ``name``."""
+        self._mode = name
+        api.select_pipeline(name)
+
+    def process(self, frame) -> dict:
+        """Process a BGR ``frame`` using the active pipeline."""
+        return api.process(frame, return_overlay=True)
 
     # -------- Camera control --------
 
@@ -68,7 +74,7 @@ class VisionInterface:
     def _apply_pipeline(self):
         frame_rgb = self.camera.capture_rgb()
         frame = cv2.cvtColor(frame_rgb, cv2.COLOR_RGB2BGR)
-        api.process_frame(frame, return_overlay=True)
+        api.process(frame, return_overlay=True)
         if self._logger:
             self._logger.log(frame, result=api.get_last_result())
         frame = draw_result(frame, api.get_last_result())
@@ -85,7 +91,7 @@ class VisionInterface:
         ready.
         """
         if self._streaming:
-            print("[VisionInterface] Streaming already running.")
+            print("[VisionManager] Streaming already running.")
             return
         if not self.camera.is_running():
             self.camera.start()
@@ -105,12 +111,12 @@ class VisionInterface:
                         with self._lock:
                             self._last_encoded_image = encoded
                 except CameraCaptureError as e:
-                    print(f"[VisionInterface] Capture error: {e}")
+                    print(f"[VisionManager] Capture error: {e}")
                     self._last_error = e
                     self._streaming = False
                     break
                 except Exception as e:
-                    print(f"[VisionInterface] Error in periodic capture: {e}")
+                    print(f"[VisionManager] Error in periodic capture: {e}")
                 sleep_s = next_tick - time.monotonic()
                 if sleep_s > 0:
                     time.sleep(sleep_s)
@@ -119,7 +125,7 @@ class VisionInterface:
 
         self._thread = threading.Thread(target=_capture_loop, daemon=True)
         self._thread.start()
-        print("[VisionInterface] Started stream thread.")
+        print("[VisionManager] Started stream thread.")
 
     def snapshot(self) -> Optional[str]:
         """Capture, process and return a single frame as base64 JPEG."""

--- a/Server/core/vision/api.py
+++ b/Server/core/vision/api.py
@@ -37,15 +37,20 @@ def update_dynamic(which: str, params: Dict[str, Any]) -> None:
     _pipeline().update_dynamic(which, params)
 
 
-def select_detector(mode: str) -> None:
-    """Select vision pipeline mode."""
+def register_pipeline(name: str, pipeline: BasePipeline) -> None:
+    """Register a new pipeline under ``name``."""
+    _PIPELINES[name] = pipeline
+
+
+def select_pipeline(name: str) -> None:
+    """Select vision pipeline by ``name``."""
     global _CURRENT
-    if mode not in _PIPELINES:
-        raise ValueError("mode must be 'object' or 'face'")
-    _CURRENT = mode
+    if name not in _PIPELINES:
+        raise ValueError("unknown pipeline")
+    _CURRENT = name
 
 
-def process_frame(
+def process(
     frame: np.ndarray,
     return_overlay: bool = True,
     config: Optional[Dict[str, Any]] = None,
@@ -59,7 +64,7 @@ def process_frame(
 
 # VisionLogger fetches the latest detection result through this helper.
 def get_last_result() -> Optional[Result]:
-    """Return the most recent Result produced by :func:`process_frame`."""
+    """Return the most recent Result produced by :func:`process`."""
     return _pipeline().get_last_result()
 
 
@@ -73,3 +78,8 @@ def create_logger_from_env() -> Optional["VisionLogger"]:
     from .viz_logger import create_logger_from_env as _create_logger_from_env
 
     return _create_logger_from_env()
+
+
+# Backwards compatibility for older imports
+select_detector = select_pipeline
+process_frame = process

--- a/Server/core/vision/detectors/README.md
+++ b/Server/core/vision/detectors/README.md
@@ -27,8 +27,8 @@ from core.vision.detectors.contour_detector import ContourDetector
 det = ContourDetector.from_profile("profile_big_solid.json")
 res = det.detect(frame_bgr, knobs={"return_overlay": True})
 
-from core.vision.api import process_frame
-out = process_frame(frame_bgr, return_overlay=True, config={"roi_factor":1.8, "ema":0.7})
+from core.vision.api import process
+out = process(frame_bgr, return_overlay=True, config={"roi_factor":1.8, "ema":0.7})
 ```
 
 ## Tips rápidos

--- a/Server/core/vision/logger_README.md
+++ b/Server/core/vision/logger_README.md
@@ -27,5 +27,5 @@ and returns a configured logger or `None` when logging is disabled.
 
 ## Notes for developers
 `VisionLogger` lazily imports the vision API to avoid circular dependencies.
-`VisionInterface` accepts an existing logger and delegates all logging work to
+`VisionManager` accepts an existing logger and delegates all logging work to
 it via the API's `create_logger_from_env()` helper.

--- a/Server/core/vision/overlays.py
+++ b/Server/core/vision/overlays.py
@@ -45,7 +45,7 @@ def draw_result(frame: np.ndarray, result: EngineResult) -> np.ndarray:
     """Draw detection information from ``result`` onto ``frame``.
 
     The drawing logic mirrors the overlay produced by
-    :meth:`VisionInterface._apply_pipeline`.  The input frame is modified
+    :meth:`VisionManager._apply_pipeline`.  The input frame is modified
     in-place and returned for convenience.
     """
     if result is None or not isinstance(result, EngineResult):

--- a/Server/core/vision/viz_logger.py
+++ b/Server/core/vision/viz_logger.py
@@ -23,7 +23,7 @@ class VisionLogger:
         output_dir: Optional[str] = None,
         stride: int = 5,
         api_config: Optional[dict] = None,
-        process_frame: Optional[Callable] = None,
+        process: Optional[Callable] = None,
         get_detectors: Optional[Callable] = None,
     ):
         ts = time.strftime("%Y%m%d_%H%M%S")
@@ -40,7 +40,7 @@ class VisionLogger:
         self.stride = max(1,int(stride))
         self.idx = 0
         self.api_cfg = dict(api_config or {})
-        self._process_frame = process_frame
+        self._process = process
         self._get_detectors = get_detectors
         self.det_big: Optional[ContourDetector]
         self.det_small: Optional[ContourDetector]
@@ -49,10 +49,10 @@ class VisionLogger:
 
     def _ensure_api(self) -> None:
         """Lazily import vision API helpers and detectors."""
-        if self._process_frame is None or self._get_detectors is None:
+        if self._process is None or self._get_detectors is None:
             from . import api as _api
-            if self._process_frame is None:
-                self._process_frame = _api.process_frame
+            if self._process is None:
+                self._process = _api.process
             if self._get_detectors is None:
                 self._get_detectors = _api.get_detectors
         if (self.det_big is None or self.det_small is None) and self._get_detectors:
@@ -124,7 +124,7 @@ class VisionLogger:
     def step(self, frame_bgr: np.ndarray):
         """Procesa un frame y devuelve overlay para visualizar."""
         self._ensure_api()
-        self._process_frame(frame_bgr, return_overlay=True, config=self.api_cfg)
+        self._process(frame_bgr, return_overlay=True, config=self.api_cfg)
         from . import api as _api
         result = _api.get_last_result() or EngineResult({}, time.time())
         self.log(frame_bgr, result)

--- a/Server/test_codes/test_visual_perception.py
+++ b/Server/test_codes/test_visual_perception.py
@@ -5,10 +5,10 @@ import base64, datetime, time
 # Ensure the Server package is on the Python path when run directly
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 
-from core.VisionInterface import VisionInterface
+from core.vision.VisionManager import VisionManager
 
 def main():
-    cam = VisionInterface()
+    cam = VisionManager()
     os.makedirs("logs", exist_ok=True)
     ts = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
     filename = f"logs/{ts}.jpg"
@@ -30,3 +30,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+


### PR DESCRIPTION
## Summary
- rename VisionInterface to VisionManager and expose pipeline registration
- align vision API with register/select/process helpers
- update services, docs, and helpers to import the new VisionManager

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy', No module named 'spidev')*


------
https://chatgpt.com/codex/tasks/task_e_68b7173e7c50832eb1b815c7df77db73