### PR TITLE
refactor: relocate VisionManager to core package

### DIFF
--- a/Server/app/services/vision_service.py
+++ b/Server/app/services/vision_service.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from typing import Optional
 
-from core.vision.VisionManager import VisionManager
+from core.VisionManager import VisionManager
 
 class VisionService:
     def __init__(self, vm: Optional[VisionManager] = None) -> None:

--- a/Server/core/VisionManager.py
+++ b/Server/core/VisionManager.py
@@ -5,12 +5,12 @@ from typing import Optional, TYPE_CHECKING
 
 import cv2
 
-from . import api
-from .camera import Camera, CameraCaptureError
-from .overlays import draw_result
+from .vision import api
+from .vision.camera import Camera, CameraCaptureError
+from .vision.overlays import draw_result
 
 if TYPE_CHECKING:  # pragma: no cover - for type checkers only
-    from .viz_logger import VisionLogger
+    from .vision.viz_logger import VisionLogger
 
 
 class VisionManager:

--- a/Server/core/__init__.py
+++ b/Server/core/__init__.py
@@ -1,0 +1,6 @@
+"""Core subsystem exports."""
+
+from .VisionManager import VisionManager
+
+__all__ = ["VisionManager"]
+

--- a/Server/test_codes/test_visual_perception.py
+++ b/Server/test_codes/test_visual_perception.py
@@ -5,7 +5,7 @@ import base64, datetime, time
 # Ensure the Server package is on the Python path when run directly
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 
-from core.vision.VisionManager import VisionManager
+from core.VisionManager import VisionManager
 
 def main():
     cam = VisionManager()


### PR DESCRIPTION
## Summary
- move VisionManager.py from core/vision to core
- update imports and package exports to reflect new location
- adjust app and test scripts to use core.VisionManager

## Testing
- `python -m py_compile core/VisionManager.py app/services/vision_service.py test_codes/test_visual_perception.py`
- `python -m app.services.vision_service` *(fails: ModuleNotFoundError: No module named 'cv2')*
- `python test_codes/test_visual_perception.py` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_68b71e06fa60832eb6b109746573efbd