### PR TITLE
Add Haar-cascade face detection pipeline

### DIFF
--- a/Server/core/vision/api.py
+++ b/Server/core/vision/api.py
@@ -11,9 +11,17 @@ from .pipeline import BasePipeline, ContourPipeline, FacePipeline, Result
 if TYPE_CHECKING:  # pragma: no cover - for type checkers only
     from .viz_logger import VisionLogger
 
+_FACE_DEFAULTS: Dict[str, Any] = dict(
+    scale_factor=1.1,
+    min_neighbors=5,
+    min_size=(40, 40),
+    equalize_hist=True,
+    resize_ratio=1.0,
+)
+
 _PIPELINES: Dict[str, BasePipeline] = {
     "object": ContourPipeline(),
-    "face": FacePipeline(),
+    "face": FacePipeline(_FACE_DEFAULTS),
 }
 _CURRENT: str = "object"
 

--- a/Server/core/vision/overlays.py
+++ b/Server/core/vision/overlays.py
@@ -55,6 +55,32 @@ def draw_result(frame: np.ndarray, result: EngineResult) -> np.ndarray:
     if not res.get("ok"):
         return frame
 
+    # Special handling for face detection results --------------------
+    if res.get("type") == "face" and isinstance(res.get("faces"), list):
+        ref_w, ref_h = _get_reference_resolution(res)
+        sx = frame.shape[1] / ref_w
+        sy = frame.shape[0] / ref_h
+        for face in res.get("faces", []):
+            x = face.get("x")
+            y = face.get("y")
+            w = face.get("w")
+            h = face.get("h")
+            if None in (x, y, w, h):
+                continue
+            x2, y2 = int(x * sx), int(y * sy)
+            w2, h2 = int(w * sx), int(h * sy)
+            cv2.rectangle(frame, (x2, y2), (x2 + w2, y2 + h2), (0, 255, 0), 2)
+            cv2.putText(
+                frame,
+                "face",
+                (x2, max(10, y2 - 5)),
+                cv2.FONT_HERSHEY_SIMPLEX,
+                0.5,
+                (0, 255, 0),
+                1,
+            )
+        return frame
+
     ref_w, ref_h = _get_reference_resolution(res)
     sx = frame.shape[1] / ref_w
     sy = frame.shape[0] / ref_h

--- a/Server/core/vision/pipeline/face_pipeline.py
+++ b/Server/core/vision/pipeline/face_pipeline.py
@@ -1,33 +1,167 @@
-"""Stub face detection pipeline to validate modularity."""
+"""Lightweight face detection pipeline using OpenCV Haar cascades."""
 
 from __future__ import annotations
 
-from typing import Any, Dict, Optional, Tuple
+import os
 import time
+from typing import Any, Dict, Optional, Tuple
+
+import cv2
 import numpy as np
 
 from .base_pipeline import BasePipeline, Result
 
 
 class FacePipeline(BasePipeline):
-    """Placeholder pipeline for face detection."""
+    """Haar-cascade based face detection pipeline."""
 
-    def process(self, frame: np.ndarray, config: Optional[Dict[str, Any]] = None) -> Result:
-        # This stub simply returns a not-implemented result.
-        data: Dict[str, Any] = {"ok": False, "reason": "face detection not implemented"}
-        return Result(data, time.time())
+    def __init__(self, config: Optional[Dict[str, Any]] = None) -> None:
+        """Initialize pipeline with optional configuration.
 
-    def reset_state(self) -> None:  # pragma: no cover - stub
+        Parameters
+        ----------
+        config:
+            Optional dictionary overriding default parameters.
+        """
+
+        path = os.path.join(
+            cv2.data.haarcascades, "haarcascade_frontalface_default.xml"
+        )
+        if not os.path.exists(path):
+            raise RuntimeError(f"Haar cascade not found: {path}")
+        self._cascade_path = path
+        self._cascade: Optional[cv2.CascadeClassifier] = None
+
+        self.cfg: Dict[str, Any] = {
+            "scale_factor": 1.1,
+            "min_neighbors": 5,
+            "min_size": (40, 40),
+            "equalize_hist": True,
+            "resize_ratio": 1.0,
+        }
+        if config:
+            self.cfg.update(config)
+
+        self._last_result: Optional[Result] = None
+
+    # ------------------------------------------------------------------
+    def _get_cascade(self) -> cv2.CascadeClassifier:
+        if self._cascade is None:
+            self._cascade = cv2.CascadeClassifier(self._cascade_path)
+            if self._cascade.empty():
+                raise RuntimeError(
+                    f"Failed to load Haar cascade: {self._cascade_path}"
+                )
+        return self._cascade
+
+    # ------------------------------------------------------------------
+    def process(
+        self,
+        frame: np.ndarray,
+        config: Optional[Dict[str, Any]] = None,
+        ts: Optional[float] = None,
+    ) -> Result:
+        """Detect faces in ``frame``.
+
+        Parameters
+        ----------
+        frame:
+            BGR image to process.
+        config:
+            Optional overrides for detector parameters.
+        ts:
+            Optional timestamp propagated into the result.
+        """
+
+        cfg = dict(self.cfg)
+        if config:
+            cfg.update(config)
+        return_overlay = bool(cfg.pop("return_overlay", False))
+
+        gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+        if cfg.get("equalize_hist", True):
+            gray = cv2.equalizeHist(gray)
+
+        ratio = float(cfg.get("resize_ratio", 1.0))
+        work = gray
+        if 0 < ratio < 1.0:
+            work = cv2.resize(gray, None, fx=ratio, fy=ratio)
+
+        cascade = self._get_cascade()
+        rects = cascade.detectMultiScale(
+            work,
+            scaleFactor=float(cfg.get("scale_factor", 1.1)),
+            minNeighbors=int(cfg.get("min_neighbors", 5)),
+            minSize=tuple(cfg.get("min_size", (40, 40))),
+        )
+
+        if 0 < ratio < 1.0:
+            inv = 1.0 / ratio
+            rects = [
+                (int(x * inv), int(y * inv), int(w * inv), int(h * inv))
+                for (x, y, w, h) in rects
+            ]
+
+        faces = [
+            {"x": int(x), "y": int(y), "w": int(w), "h": int(h)}
+            for (x, y, w, h) in rects
+        ]
+
+        data: Dict[str, Any] = {
+            "ok": True,
+            "type": "face",
+            "faces": faces,
+            "count": len(faces),
+            "ts": ts,
+            "space": (frame.shape[1], frame.shape[0]),
+        }
+        if return_overlay:
+            data["overlay"] = self.draw_result(frame.copy(), data)
+
+        res = Result(data, ts if ts is not None else time.time())
+        self._last_result = res
+        return res
+
+    # ------------------------------------------------------------------
+    def draw_result(self, frame: np.ndarray, result: Dict[str, Any]) -> np.ndarray:
+        """Draw detection ``result`` onto ``frame``."""
+        faces = result.get("faces") or []
+        for box in faces:
+            x = int(box.get("x", 0))
+            y = int(box.get("y", 0))
+            w = int(box.get("w", 0))
+            h = int(box.get("h", 0))
+            cv2.rectangle(frame, (x, y), (x + w, y + h), (0, 255, 0), 2)
+            cv2.putText(
+                frame,
+                "face",
+                (x, max(10, y - 5)),
+                cv2.FONT_HERSHEY_SIMPLEX,
+                0.5,
+                (0, 255, 0),
+                1,
+                cv2.LINE_AA,
+            )
+        return frame
+
+    # ------------------------------------------------------------------
+    def reset_state(self) -> None:
+        """No internal state to reset."""
         return None
 
-    def load_profile(self, which: str, path: Optional[str] = None) -> None:  # pragma: no cover - stub
+    def load_profile(self, which: str, path: Optional[str] = None) -> None:
+        """Profiles not supported for face detection."""
         return None
 
-    def update_dynamic(self, which: str, params: Dict[str, Any]) -> None:  # pragma: no cover - stub
+    def update_dynamic(self, which: str, params: Dict[str, Any]) -> None:
+        """Dynamic parameters not supported for face detection."""
         return None
 
-    def get_last_result(self) -> Optional[Result]:  # pragma: no cover - stub
-        return None
+    def get_last_result(self) -> Optional[Result]:
+        """Return the last :class:`Result`."""
+        return self._last_result
 
-    def get_detectors(self) -> Tuple[Any, Any]:  # pragma: no cover - stub
-        return (None, None)
+    def get_detectors(self) -> Tuple[Any, Any]:
+        """Return the underlying detector (cascade classifier)."""
+        return (self._cascade, None)
+


### PR DESCRIPTION
## Summary
- implement configurable Haar cascade FacePipeline
- register face pipeline defaults in vision API
- support drawing face results in overlays

## Testing
- `pytest` *(fails: No module named 'network', 'gui', 'numpy', 'spidev', 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_68b8417a75d4832ea23d2b59839cbdf3