### PR TITLE
Add vision mode option to configuration

### DIFF
--- a/Server/app/application.py
+++ b/Server/app/application.py
@@ -18,7 +18,8 @@ def main(config_path: str = CONFIG_PATH) -> None:
     vision_cfg = cfg.get("vision", {}) or {}
     ws_cfg = cfg.get("ws", {}) or {}
 
-    svc = VisionService()
+    mode = vision_cfg.get("mode", "object")
+    svc = VisionService(mode=mode)
 
     if enable_vision:
         interval = float(vision_cfg.get("interval_sec", 1.0))

--- a/Server/app/config/app.json
+++ b/Server/app/config/app.json
@@ -2,7 +2,8 @@
   "enable_vision": true,
   "enable_ws": true,
   "vision": {
-    "interval_sec": 1.0
+    "interval_sec": 1.0,
+    "mode": "object"
   },
   "ws": {
     "host": "0.0.0.0",

--- a/Server/app/services/vision_service.py
+++ b/Server/app/services/vision_service.py
@@ -4,12 +4,14 @@ from typing import Optional
 from core.VisionManager import VisionManager
 
 class VisionService:
-    def __init__(self, vm: Optional[VisionManager] = None) -> None:
+    def __init__(self, vm: Optional[VisionManager] = None, mode: str = "object") -> None:
         self.vm = vm or VisionManager()
+        self._mode = mode
         self._running = False
 
     def start(self, interval_sec: float = 1.0) -> None:
         if not self._running:
+            self.vm.select_pipeline(self._mode)
             self.vm.start()
             self.vm.start_stream(interval_sec=interval_sec)
             self._running = True


### PR DESCRIPTION
## Summary
- allow selecting vision pipeline via `mode` in config
- propagate vision mode to `VisionService` and application startup

## Testing
- `PYTHONDONTWRITEBYTECODE=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'network')*

------
https://chatgpt.com/codex/tasks/task_e_68b84d58c608832e88361b04f061c2c8