### PR TITLE
Add optional movement control

### DIFF
--- a/Server/app/config/app.json
+++ b/Server/app/config/app.json
@@ -1,6 +1,7 @@
 {
   "enable_vision": true,
   "enable_ws": true,
+  "enable_movement": true,
   "vision": {
     "interval_sec": 1.0,
     "mode": "object"


### PR DESCRIPTION
## Summary
- add `enable_movement` flag to config
- start MovementControl loop on its own thread when enabled

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'network')*

------
https://chatgpt.com/codex/tasks/task_e_68b8593a8898832e82fff02242367b7a