### PR TITLE
Add MovementService wrapper for movement control

### DIFF
--- a/Server/app/application.py
+++ b/Server/app/application.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
-import os, sys, json, time, threading
+import os, sys, json, time
 from typing import Any, Dict
 from app.services.vision_service import VisionService
+from app.services.movement_service import MovementService
 from network.ws_server import start_ws_server
-from core.MovementControl import MovementControl
 
 CONFIG_PATH = os.path.join(os.path.dirname(__file__), "config", "app.json")
 
@@ -24,8 +24,8 @@ def main(config_path: str = CONFIG_PATH) -> None:
     svc = VisionService(mode=mode)
 
     if enable_movement:
-        mc = MovementControl()
-        threading.Thread(target=mc.start_loop, daemon=True).start()
+        mc = MovementService()
+        mc.start()
         mc.relax()
     else:
         print("[App] Movement disabled in config.")

--- a/Server/app/services/movement_service.py
+++ b/Server/app/services/movement_service.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import threading
+from typing import Any, Optional
+
+from core.MovementControl import MovementControl
+
+
+class MovementService:
+    """Service wrapper around :class:`MovementControl`."""
+
+    def __init__(self, mc: Optional[MovementControl] = None) -> None:
+        self.mc = mc or MovementControl()
+        self._thread: Optional[threading.Thread] = None
+        self._running = False
+
+    def start(self) -> None:
+        if not self._running:
+            self._thread = threading.Thread(target=self.mc.start_loop, daemon=True)
+            self._thread.start()
+            self._running = True
+
+    def stop(self) -> None:
+        if self._running:
+            self.mc.stop()
+            self._running = False
+
+    def relax(self) -> None:
+        self.mc.relax()
+
+    def __getattr__(self, name: str) -> Any:  # pragma: no cover - simple delegation
+        return getattr(self.mc, name)


### PR DESCRIPTION
## Summary
- add MovementService to wrap MovementControl with start/stop/relax helpers
- use MovementService in application instead of direct MovementControl

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'network', cv2, numpy, spidev)*

------
https://chatgpt.com/codex/tasks/task_e_68b85b733d7c832e9f2005b90096fcdb