### PR TITLE
feat: add vision frame callback

### DIFF
--- a/Server/app/application.py
+++ b/Server/app/application.py
@@ -13,6 +13,12 @@ def _load_json(path: str) -> Dict[str, Any]:
 
 def main(config_path: str = CONFIG_PATH) -> None:
     cfg = _load_json(config_path)
+    latest_face_detection: Dict[str, Any] = {}
+
+    def _store_latest_detection(result: Dict[str, Any]) -> None:
+        latest_face_detection.clear()
+        if result:
+            latest_face_detection.update(result)
 
     enable_vision = bool(cfg.get("enable_vision", True))
     enable_ws = bool(cfg.get("enable_ws", True))
@@ -33,7 +39,7 @@ def main(config_path: str = CONFIG_PATH) -> None:
     if enable_vision:
         interval = float(vision_cfg.get("interval_sec", 1.0))
         print(f"[App] Starting vision stream (interval={interval}s)")
-        svc.start(interval_sec=interval)
+        svc.start(interval_sec=interval, frame_handler=_store_latest_detection)
     else:
         print("[App] Vision disabled in config.")
 

--- a/Server/app/services/vision_service.py
+++ b/Server/app/services/vision_service.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Optional
+from typing import Optional, Callable
 
 from core.VisionManager import VisionManager
 
@@ -9,11 +9,15 @@ class VisionService:
         self._mode = mode
         self._running = False
 
-    def start(self, interval_sec: float = 1.0) -> None:
+    def start(
+        self,
+        interval_sec: float = 1.0,
+        frame_handler: Optional[Callable[[dict], None]] = None,
+    ) -> None:
         if not self._running:
             self.vm.select_pipeline(self._mode)
             self.vm.start()
-            self.vm.start_stream(interval_sec=interval_sec)
+            self.vm.start_stream(interval_sec=interval_sec, on_frame=frame_handler)
             self._running = True
 
     def stop(self) -> None:


### PR DESCRIPTION
## Summary
- allow VisionManager to invoke an optional callback for every processed frame
- expose frame callback via VisionService.start
- store the latest face detection through a handler in application startup

## Testing
- `python -m py_compile Server/app/services/vision_service.py Server/app/application.py Server/core/VisionManager.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'network', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b85c913f44832eaf940c27c3a51b03