### PR TITLE
Handle optional vision results in callbacks

### DIFF
--- a/Server/app/application.py
+++ b/Server/app/application.py
@@ -15,7 +15,7 @@ def main(config_path: str = CONFIG_PATH) -> None:
     cfg = _load_json(config_path)
     latest_face_detection: Dict[str, Any] = {}
 
-    def _store_latest_detection(result: Dict[str, Any]) -> None:
+    def _store_latest_detection(result: Dict[str, Any] | None) -> None:
         latest_face_detection.clear()
         if result:
             latest_face_detection.update(result)

--- a/Server/app/services/vision_service.py
+++ b/Server/app/services/vision_service.py
@@ -12,7 +12,7 @@ class VisionService:
     def start(
         self,
         interval_sec: float = 1.0,
-        frame_handler: Optional[Callable[[dict], None]] = None,
+        frame_handler: Optional[Callable[[dict | None], None]] = None,
     ) -> None:
         if not self._running:
             self.vm.select_pipeline(self._mode)

--- a/Server/core/VisionManager.py
+++ b/Server/core/VisionManager.py
@@ -85,7 +85,7 @@ class VisionManager:
     def start_stream(
         self,
         interval_sec: float = 1.0,
-        on_frame: Optional[Callable[[dict], None]] = None,
+        on_frame: Optional[Callable[[dict | None], None]] = None,
     ) -> None:
         """Start periodic capture and processing in a background thread.
 
@@ -111,7 +111,8 @@ class VisionManager:
                     frame = self._apply_pipeline()
                     if on_frame:
                         try:
-                            on_frame(api.get_last_result())
+                            res = api.get_last_result()
+                            on_frame(res.data if res else None)
                         except Exception as cb_exc:
                             print(f"[VisionManager] Frame callback error: {cb_exc}")
                     ok, buffer = cv2.imencode(".jpg", frame)


### PR DESCRIPTION
## Summary
- pass result data or None to frame callbacks in VisionManager
- update vision service and app handlers to accept `dict | None`

## Testing
- `python -m pytest` *(fails: ModuleNotFoundError: No module named 'network', 'gui', 'numpy', 'spidev', 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_68b85f4b44a0832e98598cc83a8e7508