### PR TITLE
Log head movement once in face tracker

### DIFF
--- a/Server/core/face_tracker.py
+++ b/Server/core/face_tracker.py
@@ -68,7 +68,6 @@ class FaceTracker:
             return
         delta = self.pid.PID_compute(error) * self.pid_scale
         target = _clamp(self.current_head_deg + delta, min_deg, max_deg)
-        self.logger.debug("error=%.3f, delta=%.2f, target=%.1f", error, delta, target)
         self.current_head_deg = target
         self.movement.head_deg(self.current_head_deg, duration_ms=100)
         self.logger.debug("error=%.3f, delta=%.2f, target=%.1f", error, delta, target)


### PR DESCRIPTION
## Summary
- avoid duplicate debug logs when adjusting head position in `FaceTracker.update`

## Testing
- `python -m pytest` *(fails: ModuleNotFoundError: No module named 'network', 'gui', 'numpy', 'spidev', 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_68b86cd05eb0832e9dea297250140db6