### PR TITLE
Move FaceTracker into app services package

### DIFF
--- a/Server/app/application.py
+++ b/Server/app/application.py
@@ -3,7 +3,7 @@ import os, sys, json, time, logging
 from typing import Any, Dict
 from app.services.vision_service import VisionService
 from app.services.movement_service import MovementService
-from core.face_tracker import FaceTracker
+from app.services.face_tracker import FaceTracker
 from network.ws_server import start_ws_server
 from app.logging_config import setup_logging
 

--- a/Server/app/services/face_tracker.py
+++ b/Server/app/services/face_tracker.py
@@ -5,7 +5,7 @@ import logging
 
 from control.pid import Incremental_PID
 
-from .MovementControl import MovementControl
+from core.MovementControl import MovementControl
 
 
 def _clamp(val: float, mn: float, mx: float) -> float:


### PR DESCRIPTION
## Summary
- relocate FaceTracker from `core` into `app.services`
- adjust imports to use new location
- ensure services package exports face tracking logic

## Testing
- `python -m py_compile Server/app/services/face_tracker.py Server/app/application.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'network', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b965162c28832e81bbff1e1ad4e7e3