### PR TITLE
Add camera FPS and face vision config

### DIFF
--- a/Server/app/application.py
+++ b/Server/app/application.py
@@ -34,7 +34,9 @@ def main(config_path: str = CONFIG_PATH) -> None:
     ws_cfg = cfg.get("ws", {}) or {}
 
     mode = vision_cfg.get("mode", "object")
-    svc = VisionService(mode=mode)
+    camera_fps = float(vision_cfg.get("camera_fps", 15.0))
+    face_cfg = vision_cfg.get("face", {}) or {}
+    svc = VisionService(mode=mode, camera_fps=camera_fps, face_cfg=face_cfg)
 
     face_tracker: FaceTracker | None = None
     if enable_movement:

--- a/Server/app/config/app.json
+++ b/Server/app/config/app.json
@@ -3,8 +3,15 @@
   "enable_ws": true,
   "enable_movement": true,
   "vision": {
-    "interval_sec": 1.0,
-    "mode": "object"
+    "interval_sec": 0.1,
+    "camera_fps": 15,
+    "mode": "object",
+    "face": {
+      "resize_ratio": 0.5,
+      "min_size": [40, 40],
+      "scale_factor": 1.1,
+      "min_neighbors": 5
+    }
   },
   "ws": {
     "host": "0.0.0.0",

--- a/Server/app/services/vision_service.py
+++ b/Server/app/services/vision_service.py
@@ -1,13 +1,26 @@
 from __future__ import annotations
-from typing import Optional, Callable
+from typing import Optional, Callable, Dict, Any
+
+import cv2
 
 from core.VisionManager import VisionManager
+import core.vision.profile_manager as pm
+from core.vision import api
+from core.vision.pipeline.face_pipeline import FacePipeline
 
 class VisionService:
-    def __init__(self, vm: Optional[VisionManager] = None, mode: str = "object") -> None:
+    def __init__(
+        self,
+        vm: Optional[VisionManager] = None,
+        mode: str = "object",
+        camera_fps: float = 15.0,
+        face_cfg: Optional[Dict[str, Any]] = None,
+    ) -> None:
         self.vm = vm or VisionManager()
         self._mode = mode
         self._running = False
+        self._camera_fps = float(camera_fps)
+        self._face_cfg = dict(face_cfg or {})
 
     def start(
         self,
@@ -15,6 +28,13 @@ class VisionService:
         frame_handler: Optional[Callable[[dict | None], None]] = None,
     ) -> None:
         if not self._running:
+            try:
+                cv2.setNumThreads(1)
+            except Exception:
+                pass
+            if self._face_cfg:
+                api.register_pipeline("face", FacePipeline(self._face_cfg))
+            pm._profiles.setdefault("vision", {}).update({"camera_fps": self._camera_fps})
             self.vm.select_pipeline(self._mode)
             self.vm.start()
             self.vm.start_stream(interval_sec=interval_sec, on_frame=frame_handler)


### PR DESCRIPTION
## Summary
- expand vision config with camera FPS and face detection parameters
- propagate new vision config to VisionService and VisionManager
- limit OpenCV to single thread during vision initialization

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'network')*
- `python -m py_compile Server/app/application.py Server/app/services/vision_service.py`


------
https://chatgpt.com/codex/tasks/task_e_68b972487454832ea9f99cfad1e9ee1f