### PR TITLE
docs: document logging information

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,4 @@ Part of the code comes from the [official Freenove repository] (https://github.c
 ## Project status
 This project is in its early stages; documentation and code will grow as learning progresses.
 
-## Logging
-
-The server application records runtime information to a rotating log file
-`robot.log` in the project root. The file keeps up to three 1&nbsp;MB
-rotations. Run the application normally and inspect the file with tools like
-`tail -f robot.log` to monitor activity.
+For information about application logs, see [docs/logging.md](docs/logging.md).

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,13 @@
+# Logging
+
+The server application records runtime information to a rotating log file named `robot.log` at the root of the project.
+The log keeps up to three rotations, each limited to 1&nbsp;MB.
+
+To monitor activity in real time, run:
+
+```bash
+tail -f robot.log
+```
+
+You can also inspect older entries with tools such as `less` or `grep`.
+


### PR DESCRIPTION
## Summary
- Move logging instructions from main README to docs/logging.md
- Add link in README pointing to detailed logging docs

## Testing
- `pytest` *(fails: ModuleNotFoundError for network, gui, numpy, spidev, cv2)*

------
https://chatgpt.com/codex/tasks/task_e_68befeedf630832e9b0c315a6a117a85