### PR TITLE
Add timed turn helpers and movement service delegation tests

### DIFF
--- a/Server/app/services/movement_service.py
+++ b/Server/app/services/movement_service.py
@@ -28,5 +28,13 @@ class MovementService:
     def relax(self) -> None:
         self.mc.relax()
 
+    def turn_left(self, duration_ms: int, speed: float) -> None:
+        """Delegate a left in-place turn to :class:`MovementControl`."""
+        self.mc.turn_left(duration_ms, speed)
+
+    def turn_right(self, duration_ms: int, speed: float) -> None:
+        """Delegate a right in-place turn to :class:`MovementControl`."""
+        self.mc.turn_right(duration_ms, speed)
+
     def __getattr__(self, name: str) -> Any:  # pragma: no cover - simple delegation
         return getattr(self.mc, name)

--- a/Server/tests/test_movement_service.py
+++ b/Server/tests/test_movement_service.py
@@ -1,0 +1,38 @@
+from unittest.mock import MagicMock
+from pathlib import Path
+import sys
+import types
+
+ROOT = Path(__file__).resolve().parents[2]
+# Make Server package available
+sys.path.append(str(ROOT / "Server"))
+
+# Provide a stub MovementControl to avoid heavy imports
+core_mod = types.ModuleType("core")
+
+class MovementControl:
+    def turn_left(self, duration_ms, speed):
+        pass
+
+    def turn_right(self, duration_ms, speed):
+        pass
+
+core_mod.MovementControl = MovementControl
+sys.modules["core"] = core_mod
+sys.modules["core.MovementControl"] = core_mod
+
+from app.services.movement_service import MovementService
+
+
+def test_turn_left_delegates():
+    mc = MagicMock(spec=MovementControl)
+    svc = MovementService(mc)
+    svc.turn_left(100, 1.0)
+    mc.turn_left.assert_called_once_with(100, 1.0)
+
+
+def test_turn_right_delegates():
+    mc = MagicMock(spec=MovementControl)
+    svc = MovementService(mc)
+    svc.turn_right(200, 2.0)
+    mc.turn_right.assert_called_once_with(200, 2.0)


### PR DESCRIPTION
## Summary
- add `_turn_in_place` to schedule timed rotations and stop
- expose `turn_left` and `turn_right` in MovementControl and MovementService
- test delegation of turn helpers through MovementService

## Testing
- `pytest Server/tests/test_movement_service.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf06cc7844832e85031aa99f88ae8a