### PR TITLE
Ensure face tracker turn uses constant speed

### DIFF
--- a/Server/app/controllers/face_tracker.py
+++ b/Server/app/controllers/face_tracker.py
@@ -108,9 +108,9 @@ class FaceTracker:
             scale = min(1.0, abs(ex) * self.k_turn)
             pulse = int(_clamp(self.base_pulse_ms * scale, self.min_pulse_ms, self.max_pulse_ms))
             if ex > 0:
-                self.movement.turn_right(duration_ms=pulse, speed=scale)
+                self.movement.turn_right(duration_ms=pulse, speed=1.0)
             else:
-                self.movement.turn_left(duration_ms=pulse, speed=scale)
+                self.movement.turn_left(duration_ms=pulse, speed=1.0)
             self._turn_cooldown = pulse / 1000.0
         face_center_y = y + h / 2.0
         if self._ema_center is None:


### PR DESCRIPTION
## Summary
- use constant turn speed in face tracking controller

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'network')*

------
https://chatgpt.com/codex/tasks/task_e_68c495261ab8832eade4f82a763db56b