### PR TITLE
Add idle relaxation timeout to social FSM

### DIFF
--- a/Server/app/config/app.json
+++ b/Server/app/config/app.json
@@ -22,7 +22,8 @@
       "deadband_x": 0.12,
       "lock_frames_needed": 3,
       "miss_release": 5,
-      "interact_ms": 1500
+      "interact_ms": 1500,
+      "relax_timeout": 30
     }
   }
 }


### PR DESCRIPTION
## Summary
- track last activity in `SocialFSM` and relax movement when idle
- allow configuring idle `relax_timeout` via `app.json`

## Testing
- `pytest` *(fails: No module named 'network', 'gui', 'numpy', 'spidev', 'cv2')*


------
https://chatgpt.com/codex/tasks/task_e_68c82e889828832eba961d23becd205f