### PR TITLE
Handle empty frame results before invoking FSM

### DIFF
--- a/Server/app/application.py
+++ b/Server/app/application.py
@@ -60,7 +60,7 @@ def main(config_path: str = CONFIG_PATH) -> None:
             dt = now - prev_time
             prev_time = now
             if fsm:
-                fsm.on_frame(result, dt)
+                fsm.on_frame(result or {}, dt)
             _store_latest_detection(result)
 
         svc.start(interval_sec=interval, frame_handler=_handle_frame)


### PR DESCRIPTION
## Summary
- call the social FSM with an empty dict when the vision result is falsy to keep callbacks with no data working

## Testing
- pytest *(fails: missing modules such as network, gui, numpy, spidev, cv2)*

------
https://chatgpt.com/codex/tasks/task_e_68c8409fe3c8832e9e6f0ca4e4bbf87d