### PR TITLE
Handle None score and cooldown in social FSM

### DIFF
--- a/Server/tests/test_social_fsm_config.py
+++ b/Server/tests/test_social_fsm_config.py
@@ -88,6 +88,8 @@ def test_config_values_override_defaults():
                 "lock_frames_needed": 10,
                 "miss_release": 7,
                 "interact_ms": 2000,
+                "min_score": 0.75,
+                "cooldown_ms": 1200,
             }
         }
     }
@@ -96,4 +98,21 @@ def test_config_values_override_defaults():
     assert fsm.lock_frames_needed == 10
     assert fsm.miss_release == 7
     assert fsm.interact_ms == 2000
+    assert fsm.min_score == 0.75
+    assert fsm.cooldown == 1.2
+
+
+def test_none_config_values_fallback():
+    cfg = {
+        "behavior": {
+            "social_fsm": {
+                "min_score": None,
+                "cooldown_ms": None,
+            }
+        }
+    }
+    fsm = SocialFSM(VisionService(), MovementService(), cfg)
+    assert fsm.min_score == 0.0
+    assert fsm.cooldown == 0.0
+    fsm.on_frame({"score": None, "faces": []}, 0.1)
 


### PR DESCRIPTION
## Summary
- ensure SocialFSM reads `min_score` and `cooldown_ms` from config as floats
- ignore detections whose score falls below the configured minimum
- extend SocialFSM config tests to cover the new settings and `None` fallbacks

## Testing
- pytest Server/tests/test_social_fsm_config.py

------
https://chatgpt.com/codex/tasks/task_e_68c859b9a7e4832e9ccc937adcfd19e8