### PR TITLE
Play meow sound when face detected in social FSM

### DIFF
--- a/Server/app/controllers/social_fsm.py
+++ b/Server/app/controllers/social_fsm.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 from typing import Dict, List, Optional
 import logging
 import time
+from pathlib import Path
 
 from .face_tracker import FaceTracker
 from ..services.movement_service import MovementService
 from ..services.vision_service import VisionService
+from core.voice.sfx import play_sound
 
 
 class SocialFSM:
@@ -125,10 +127,8 @@ class SocialFSM:
 
     def _on_interact(self) -> None:
         self.last_active = time.monotonic()
-        if getattr(self, "audio", None):
-            try:
-                self.audio.play("meow1.wav")
-            except Exception:
-                logging.info("meow")
-        else:
+        sound_file = Path(__file__).resolve().parents[2] / "sounds" / "meow.wav"
+        try:
+            play_sound(sound_file)
+        except Exception:
             logging.info("meow")

--- a/Server/core/voice/sfx.py
+++ b/Server/core/voice/sfx.py
@@ -1,0 +1,29 @@
+"""Utility functions for playing short sound effects."""
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Iterable
+
+
+def _available_player(players: Iterable[str] = ("aplay", "paplay", "play")) -> str | None:
+    """Return the first available player from *players* or ``None``."""
+    for player in players:
+        if shutil.which(player):
+            return player
+    return None
+
+
+def play_sound(path: str | Path) -> None:
+    """Play a WAV file at *path* using the first available player.
+
+    If no player is available, the path is printed so the user can play the
+    sound manually.
+    """
+    wav_path = Path(path)
+    player = _available_player()
+    if player:
+        subprocess.run([player, str(wav_path)])
+    else:
+        print(f"[INFO] WAV ready at {wav_path}")


### PR DESCRIPTION
## Summary
- add `core.voice.sfx` helper for playing short WAV files via available system players
- play `sounds/meow.wav` when the social FSM enters the INTERACT state

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'network')*
- `pytest Server/test_codes/test_gamepad.py::test_gamepad -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68c9788ca530832e816075046bf0cb41