### PR TITLE
feat: add randomized meow cooldown

### DIFF
--- a/Server/app/config/app.json
+++ b/Server/app/config/app.json
@@ -23,7 +23,9 @@
       "lock_frames_needed": 3,
       "miss_release": 5,
       "interact_ms": 1500,
-      "relax_timeout": 30
+      "relax_timeout": 30,
+      "meow_cooldown_min": 5,
+      "meow_cooldown_max": 15
     }
   }
 }

--- a/Server/tests/test_social_fsm_config.py
+++ b/Server/tests/test_social_fsm_config.py
@@ -32,6 +32,19 @@ sys.modules["core"] = core_mod
 sys.modules["core.MovementControl"] = core_mod
 sys.modules["core.VisionManager"] = core_mod
 
+voice_mod = types.ModuleType("core.voice")
+sfx_mod = types.ModuleType("core.voice.sfx")
+
+
+def play_sound(_):
+    pass
+
+
+sfx_mod.play_sound = play_sound
+voice_mod.sfx = sfx_mod
+sys.modules["core.voice"] = voice_mod
+sys.modules["core.voice.sfx"] = sfx_mod
+
 control_mod = types.ModuleType("control")
 pid_mod = types.ModuleType("control.pid")
 
@@ -78,6 +91,7 @@ vision_service_mod.VisionService = VisionService
 sys.modules["app.services.vision_service"] = vision_service_mod
 
 from app.controllers.social_fsm import SocialFSM
+import app.controllers.social_fsm as social_fsm_module
 
 
 def test_config_values_override_defaults():
@@ -90,6 +104,8 @@ def test_config_values_override_defaults():
                 "interact_ms": 2000,
                 "min_score": 0.75,
                 "cooldown_ms": 1200,
+                "meow_cooldown_min": 6,
+                "meow_cooldown_max": 12,
             }
         }
     }
@@ -100,6 +116,8 @@ def test_config_values_override_defaults():
     assert fsm.interact_ms == 2000
     assert fsm.min_score == 0.75
     assert fsm.cooldown == 1.2
+    assert fsm.meow_cooldown_min == 6
+    assert fsm.meow_cooldown_max == 12
 
 
 def test_none_config_values_fallback():
@@ -108,11 +126,45 @@ def test_none_config_values_fallback():
             "social_fsm": {
                 "min_score": None,
                 "cooldown_ms": None,
+                "meow_cooldown_min": None,
+                "meow_cooldown_max": None,
             }
         }
     }
     fsm = SocialFSM(VisionService(), MovementService(), cfg)
     assert fsm.min_score == 0.0
     assert fsm.cooldown == 0.0
+    assert fsm.meow_cooldown_min == 5.0
+    assert fsm.meow_cooldown_max == 15.0
     fsm.on_frame({"score": None, "faces": []}, 0.1)
+
+
+def test_meow_cooldown_respected(monkeypatch):
+    fsm = SocialFSM(VisionService(), MovementService())
+    calls = []
+
+    def fake_play_sound(_):
+        calls.append(1)
+
+    monkeypatch.setattr(social_fsm_module, "play_sound", fake_play_sound)
+
+    t = 100.0
+
+    def fake_monotonic():
+        return t
+
+    monkeypatch.setattr(social_fsm_module.time, "monotonic", fake_monotonic)
+
+    fsm._on_interact()
+    assert len(calls) == 1
+    next_time = fsm._next_meow_time
+    assert 5.0 <= next_time - t <= 15.0
+
+    t += 1.0
+    fsm._on_interact()
+    assert len(calls) == 1
+
+    t = next_time
+    fsm._on_interact()
+    assert len(calls) == 2
 


### PR DESCRIPTION
## Summary
- prevent continuous meow sounds by adding randomized cooldown between plays
- expose configurable min/max cooldown in social_fsm config
- add tests covering configuration and cooldown behavior

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'network')*
- `pytest Server/tests/test_social_fsm_config.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c97f02902c832eb512f78eb40abcb0