### PR TITLE
Add WS configuration to services and runtime startup

### DIFF
--- a/Server/app/builder.py
+++ b/Server/app/builder.py
@@ -21,6 +21,7 @@ class AppServices:
     enable_vision: bool = True
     enable_movement: bool = True
     enable_ws: bool = True
+    ws_cfg: Dict[str, Any] = field(default_factory=dict)
     vision: Optional[VisionService] = None
     movement: Optional[MovementService] = None
     fsm: Optional[SocialFSM] = None
@@ -47,6 +48,8 @@ class AppBuilder:
         services.camera_fps = float(vision_cfg.get("camera_fps", 15.0))
         services.face_cfg = vision_cfg.get("face", {}) or {}
         services.interval_sec = float(vision_cfg.get("interval_sec", 1.0))
+
+        services.ws_cfg = cfg.get("ws", {}) or {}
 
         if services.enable_vision:
             services.vision = VisionService(

--- a/Server/app/runtime.py
+++ b/Server/app/runtime.py
@@ -4,6 +4,7 @@ import time
 from typing import Any, Callable, Dict, Optional
 
 from .builder import AppServices
+from network.ws_server import start_ws_server
 
 
 class AppRuntime:
@@ -43,3 +44,48 @@ class AppRuntime:
             self._store_latest_detection(result)
 
         self._frame_handler = _handle
+
+    def start(self) -> None:
+        """Start the application services and, if enabled, the WS server.
+
+        El apagado fino llegará en la segunda iteración; por ahora replicamos
+        el comportamiento bloqueante del script original y confiamos en
+        ``CTRL+C`` para detener la ejecución.
+        """
+
+        vision = self.svcs.vision if self.svcs.vision else None
+        movement = self.svcs.movement if self.svcs.movement else None
+
+        if movement and self.svcs.enable_movement:
+            movement.start()
+            movement.relax()
+
+        frame_handler = None
+        if vision and self.svcs.enable_vision:
+            self._register_frame_handler()
+            frame_handler = self.frame_handler
+
+        vision_started = False
+
+        try:
+            if vision and self.svcs.enable_vision:
+                vision.start(
+                    interval_sec=float(self.svcs.interval_sec or 1.0),
+                    frame_handler=frame_handler,
+                )
+                vision_started = True
+
+            if self.svcs.enable_ws and vision:
+                ws_cfg = self.svcs.ws_cfg or {}
+                host = ws_cfg.get("host", "0.0.0.0")
+                port = int(ws_cfg.get("port", 8765))
+                start_ws_server(vision, host=host, port=port)
+            elif vision_started:
+                try:
+                    while True:
+                        time.sleep(1.0)
+                except KeyboardInterrupt:
+                    pass
+        finally:
+            if vision_started and vision:
+                vision.stop()


### PR DESCRIPTION
## Summary
- store the websocket configuration on `AppServices` when building from config
- start the application runtime by orchestrating movement/vision services and launching the websocket server when enabled
- document that graceful shutdown will arrive in a later iteration while keeping the current blocking behaviour

## Testing
- python -m compileall Server/app

------
https://chatgpt.com/codex/tasks/task_e_68ca5c922ad4832eb7530a7bc9a39811