### PR TITLE
Refactor vision service pipeline setup

### DIFF
--- a/Server/app/services/vision_service.py
+++ b/Server/app/services/vision_service.py
@@ -21,23 +21,44 @@ class VisionService:
         self._running = False
         self._camera_fps = float(camera_fps)
         self._face_cfg = dict(face_cfg or {})
+        self._frame_callback: Optional[Callable[[dict | None], None]] = None
+
+    def register_face_pipeline(self, profile_name: str) -> None:
+        if not self._face_cfg:
+            return
+
+        pipeline = FacePipeline(self._face_cfg)
+        api.register_pipeline(profile_name, pipeline)
+        pm._profiles.setdefault("vision", {}).update({"camera_fps": self._camera_fps})
+        self.vm.select_pipeline(profile_name)
+
+    def set_frame_callback(
+        self, cb: Optional[Callable[[dict | None], None]]
+    ) -> None:
+        self._frame_callback = cb
 
     def start(
         self,
         interval_sec: float = 1.0,
         frame_handler: Optional[Callable[[dict | None], None]] = None,
     ) -> None:
+        handler = frame_handler if frame_handler is not None else self._frame_callback
         if not self._running:
             try:
                 cv2.setNumThreads(1)
             except Exception:
                 pass
             if self._face_cfg:
-                api.register_pipeline("face", FacePipeline(self._face_cfg))
-            pm._profiles.setdefault("vision", {}).update({"camera_fps": self._camera_fps})
-            self.vm.select_pipeline(self._mode)
+                self.register_face_pipeline("face")
+            else:
+                pm._profiles.setdefault("vision", {}).update(
+                    {"camera_fps": self._camera_fps}
+                )
+                self.vm.select_pipeline(self._mode)
+            if not (self._face_cfg and self._mode == "face"):
+                self.vm.select_pipeline(self._mode)
             self.vm.start()
-            self.vm.start_stream(interval_sec=interval_sec, on_frame=frame_handler)
+            self.vm.start_stream(interval_sec=interval_sec, on_frame=handler)
             self._running = True
 
     def stop(self) -> None:


### PR DESCRIPTION
## Summary
- add a stored frame callback so the runtime can register handlers before starting the stream
- extract face pipeline registration into a helper that configures the profile and selects the pipeline
- update `start` to reuse the stored callback when none is supplied while only handling hardware setup

## Testing
- python -m compileall Server/app/services/vision_service.py

------
https://chatgpt.com/codex/tasks/task_e_68ca5f007aac832e86b401c43b9faad1