### PR TITLE
Refine app service builder configuration loading

### DIFF
--- a/Server/app/builder.py
+++ b/Server/app/builder.py
@@ -2,11 +2,15 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Dict, Optional
 
-from .services.vision_service import VisionService
-from .services.movement_service import MovementService
 from .controllers.social_fsm import SocialFSM
+from .services.movement_service import MovementService
+from .services.vision_service import VisionService
+
+
+CONFIG_PATH = str(Path(__file__).resolve().parent / "config" / "app.json")
 
 
 @dataclass
@@ -23,64 +27,60 @@ class AppServices:
     enable_movement: bool = True
     enable_ws: bool = True
     ws_cfg: Dict[str, Any] = field(default_factory=dict)
+    ws: Optional[Any] = None
     vision: Optional[VisionService] = None
     movement: Optional[MovementService] = None
     fsm: Optional[SocialFSM] = None
 
 
-class AppBuilder:
-    """Builds application services from a configuration dictionary."""
-
-    def __init__(self, cfg: Optional[Dict[str, Any]] = None) -> None:
-        self._cfg = cfg or {}
-
-    def build(self) -> AppServices:
-        cfg = self._cfg or {}
-        services = AppServices()
-        services.cfg = cfg
-
-        services.enable_vision = bool(cfg.get("enable_vision", True))
-        services.enable_ws = bool(cfg.get("enable_ws", True))
-        services.enable_movement = bool(cfg.get("enable_movement", True))
-
-        vision_cfg = cfg.get("vision", {}) or {}
-        services.vision_cfg = vision_cfg
-        services.mode = vision_cfg.get("mode", "object")
-        services.camera_fps = float(vision_cfg.get("camera_fps", 15.0))
-        services.face_cfg = vision_cfg.get("face", {}) or {}
-        services.interval_sec = float(vision_cfg.get("interval_sec", 1.0))
-
-        services.ws_cfg = cfg.get("ws", {}) or {}
-
-        if services.enable_vision:
-            services.vision = VisionService(
-                mode=services.mode,
-                camera_fps=services.camera_fps,
-                face_cfg=services.face_cfg,
-            )
-
-        if services.enable_movement:
-            services.movement = MovementService()
-
-        if services.vision and services.movement:
-            services.fsm = SocialFSM(services.vision, services.movement, cfg)
-
-        return services
-
-
 def _load_json(path: str) -> Dict[str, Any]:
-    with open(path, "r", encoding="utf-8") as f:
-        return json.load(f)
+    with open(path, "r", encoding="utf-8") as file:
+        return json.load(file)
 
 
-def build(*, config_path: Optional[str] = None, config: Optional[Dict[str, Any]] = None) -> AppServices:
-    """Convenience helper to build :class:`AppServices` from a JSON config."""
+def build(config_path: str = CONFIG_PATH) -> AppServices:
+    """Build :class:`AppServices` instances from a configuration file."""
 
-    cfg = config
-    if cfg is None and config_path:
+    cfg: Dict[str, Any] = {}
+    if config_path:
         cfg = _load_json(config_path)
-    elif cfg is None:
-        cfg = {}
 
-    builder = AppBuilder(cfg)
-    return builder.build()
+    services = AppServices()
+    services.cfg = cfg
+
+    services.enable_vision = bool(cfg.get("enable_vision", True))
+    services.enable_ws = bool(cfg.get("enable_ws", True))
+    services.enable_movement = bool(cfg.get("enable_movement", True))
+
+    vision_cfg = cfg.get("vision", {}) or {}
+    services.vision_cfg = vision_cfg
+    services.mode = vision_cfg.get("mode", "object")
+    services.camera_fps = float(vision_cfg.get("camera_fps", 15.0))
+    services.face_cfg = vision_cfg.get("face", {}) or {}
+    services.interval_sec = float(vision_cfg.get("interval_sec", 1.0))
+
+    ws_cfg = cfg.get("ws", {}) or {}
+    services.ws_cfg = {
+        "host": ws_cfg.get("host", "0.0.0.0"),
+        "port": int(ws_cfg.get("port", 8765)),
+    }
+    services.ws = None
+
+    if services.enable_vision:
+        vision = VisionService(
+            mode=services.mode,
+            camera_fps=services.camera_fps,
+            face_cfg=services.face_cfg,
+        )
+        if services.face_cfg:
+            profile = str(services.face_cfg.get("profile", "face"))
+            vision.register_face_pipeline(profile)
+        services.vision = vision
+
+    if services.enable_movement:
+        services.movement = MovementService()
+
+    if services.vision and services.movement:
+        services.fsm = SocialFSM(services.vision, services.movement, cfg)
+
+    return services


### PR DESCRIPTION
## Summary
- add a CONFIG_PATH constant and JSON helper for loading the default app configuration
- construct AppServices directly from the configuration file while wiring vision/movement services and face pipelines when enabled
- propagate websocket host/port configuration and include a placeholder ws handle in AppServices

## Testing
- pytest *(fails: missing optional dependencies such as network, numpy, spidev, cv2)*

------
https://chatgpt.com/codex/tasks/task_e_68caa7d92394832e92e5d8a4530a8064