### PR TITLE
Update server run script to import application entrypoint

### DIFF
--- a/Server/run.py
+++ b/Server/run.py
@@ -1,15 +1,21 @@
-import os
+from __future__ import annotations
+
 import sys
+from pathlib import Path
 
-project_root = os.path.dirname(os.path.abspath(__file__))
 
-if project_root not in sys.path:
-    sys.path.insert(0, project_root)
+PROJECT_ROOT = Path(__file__).resolve().parent
 
-for folder in ['app', 'core', 'lib', 'test_codes', 'network']:
-    folder_path = os.path.join(project_root, folder)
-    if folder_path not in sys.path:
-        sys.path.insert(0, folder_path)
+project_root_str = str(PROJECT_ROOT)
+if project_root_str not in sys.path:
+    sys.path.insert(0, project_root_str)
+
+for relative_path in ("app", "core", "lib", "network", "test_codes"):
+    folder_path = PROJECT_ROOT / relative_path
+    if folder_path.exists():
+        folder_path_str = str(folder_path)
+        if folder_path_str not in sys.path:
+            sys.path.insert(0, folder_path_str)
 
 #from hello_world import main
 #from test_led_controller import main
@@ -21,5 +27,6 @@ for folder in ['app', 'core', 'lib', 'test_codes', 'network']:
 #from test_voice_interface import main
 from app.application import main
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- ensure the server run script adds the project and helper directories to `sys.path` using pathlib
- import the main entry point from `app.application` while keeping the CLI guard intact

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cabd21c608832e9c932405e8c1b0ec