### PR TITLE
Ensure face pipeline reuse in VisionService runtime

### DIFF
--- a/Server/app/runtime.py
+++ b/Server/app/runtime.py
@@ -64,6 +64,7 @@ class AppRuntime:
         if vision and self.svcs.enable_vision:
             self._register_frame_handler()
             frame_handler = self.frame_handler
+            vision.set_frame_callback(frame_handler)
 
         vision_started = False
 


### PR DESCRIPTION
## Summary
- set the VisionService frame callback from AppRuntime when registering the handler so it can be reused later by websocket-driven restarts

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cabbe8c8f8832ebe1ce85059ef937b