### PR TITLE
Propagate shutdown signal after stopping runtime

### DIFF
--- a/Server/app/runtime.py
+++ b/Server/app/runtime.py
@@ -64,6 +64,13 @@ class AppRuntime:
     def _handle_shutdown_signal(self, signum: int, frame: Optional[FrameType]) -> None:
         self.stop()
 
+        try:
+            signal.default_int_handler(signum, frame)  # type: ignore[arg-type]
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except Exception:
+            raise KeyboardInterrupt()
+
     def start(self) -> None:
         """Start the application services and, if enabled, the WS server.
 


### PR DESCRIPTION
## Summary
- propagate shutdown signals in the runtime by re-raising after invoking stop so asyncio.run can exit

## Testing
- python Server/run.py *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_68cac292357c832ea0bb9604dd36cbbf