### PR TITLE
Handle KeyboardInterrupt for WebSocket server

### DIFF
--- a/Server/app/runtime.py
+++ b/Server/app/runtime.py
@@ -112,7 +112,10 @@ class AppRuntime:
                 ws_cfg = self.svcs.ws_cfg or {}
                 host = ws_cfg.get("host", "0.0.0.0")
                 port = int(ws_cfg.get("port", 8765))
-                start_ws_server(vision, host=host, port=port)
+                try:
+                    start_ws_server(vision, host=host, port=port)
+                except KeyboardInterrupt:
+                    pass
             elif vision_started:
                 try:
                     while not self._shutdown_event.wait(timeout=1.0):


### PR DESCRIPTION
## Summary
- wrap the websocket server startup in a KeyboardInterrupt handler so shutdown completes without a traceback

## Testing
- `python Server/run.py` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_68cac727be00832e9671f4c52563a116