### PR TITLE
Add tracker configuration properties

### DIFF
--- a/Server/app/controllers/face_tracker.py
+++ b/Server/app/controllers/face_tracker.py
@@ -95,6 +95,30 @@ class FaceTracker:
         self.tracker.set_turn_gain(value)
 
     @property
+    def lock_frames_needed(self) -> int:
+        return self.tracker.lock_frames_needed
+
+    @lock_frames_needed.setter
+    def lock_frames_needed(self, value: int) -> None:
+        self.tracker.lock_frames_needed = value
+
+    @property
+    def miss_release(self) -> int:
+        return self.tracker.miss_release
+
+    @miss_release.setter
+    def miss_release(self, value: int) -> None:
+        self.tracker.miss_release = value
+
+    @property
+    def recenter_after(self) -> int:
+        return self.tracker.recenter_after
+
+    @recenter_after.setter
+    def recenter_after(self, value: int) -> None:
+        self.tracker.recenter_after = value
+
+    @property
     def current_head_deg(self) -> float:
         return self.tracker.y.current_head_deg
 

--- a/Server/app/controllers/social_fsm.py
+++ b/Server/app/controllers/social_fsm.py
@@ -33,6 +33,11 @@ class SocialFSM:
         self.tracker = FaceTracker(movement.mc, vision.vm)
         # Keep deadband consistent with the tracker so state decisions match
         self.tracker.deadband_x = self.deadband_x
+        self.tracker.lock_frames_needed = self.lock_frames_needed
+        self.tracker.miss_release = self.miss_release
+        recenter_after = behavior_cfg.get("recenter_after", 40)
+        if recenter_after is not None:
+            self.tracker.recenter_after = int(recenter_after)
 
         self.state = "IDLE"
         self.miss_frames = 0

--- a/Server/app/controllers/tracker.py
+++ b/Server/app/controllers/tracker.py
@@ -242,6 +242,9 @@ class ObjectTracker:
     _locked: bool = field(default=False, init=False)
     _face_count: int = field(default=0, init=False)
     _miss_count: int = field(default=0, init=False)
+    _lock_frames_needed: int = field(default=3, init=False, repr=False)
+    _miss_release: int = field(default=5, init=False, repr=False)
+    _recenter_after: int = field(default=40, init=False, repr=False)
 
     def __post_init__(self) -> None:
         self.x = AxisXTurnController(self.movement, self.logger)
@@ -278,6 +281,30 @@ class ObjectTracker:
             self.x.set_enabled(enable_x)
         if enable_y is not None:
             self.y.enabled = bool(enable_y)
+
+    @property
+    def lock_frames_needed(self) -> int:
+        return self._lock_frames_needed
+
+    @lock_frames_needed.setter
+    def lock_frames_needed(self, value: int) -> None:
+        self._lock_frames_needed = max(0, int(value))
+
+    @property
+    def miss_release(self) -> int:
+        return self._miss_release
+
+    @miss_release.setter
+    def miss_release(self, value: int) -> None:
+        self._miss_release = max(0, int(value))
+
+    @property
+    def recenter_after(self) -> int:
+        return self._recenter_after
+
+    @recenter_after.setter
+    def recenter_after(self, value: int) -> None:
+        self._recenter_after = max(0, int(value))
 
     # ----- Core behaviour --------------------------------------------------------
     def update(self, result: Optional[Dict[str, object]], dt: float) -> None:


### PR DESCRIPTION
## Summary
- add non-negative property accessors for lock, miss, and recenter thresholds in the object tracker
- proxy the new configuration properties through the face tracker for API compatibility
- have the social FSM push its configured tracking thresholds through the tracker to keep values in sync

## Testing
- pytest *(fails: missing optional dependencies such as numpy, cv2, and spidev required by the hardware stack)*

------
https://chatgpt.com/codex/tasks/task_e_68cc1f7abc14832ea22ad2862f90a46b