### PR TITLE
Fix ObjectTracker threshold defaults

### DIFF
--- a/Server/app/controllers/tracker.py
+++ b/Server/app/controllers/tracker.py
@@ -233,9 +233,6 @@ class ObjectTracker:
     logger: logging.Logger = field(
         default_factory=lambda: logging.getLogger("object_tracker")
     )
-    lock_frames_needed: int = 3
-    miss_release: int = 5
-    recenter_after: int = 40
     x: AxisXTurnController = field(init=False)
     y: AxisYHeadController = field(init=False)
     _had_target: bool = field(default=False, init=False)
@@ -249,6 +246,10 @@ class ObjectTracker:
     def __post_init__(self) -> None:
         self.x = AxisXTurnController(self.movement, self.logger)
         self.y = AxisYHeadController(self.movement, self.logger)
+        # Ensure compatibility defaults mirror the legacy constructor values.
+        self.lock_frames_needed = 3
+        self.miss_release = 5
+        self.recenter_after = 40
 
     # ----- Compatibility helpers -------------------------------------------------
     @property


### PR DESCRIPTION
## Summary
- stop exposing ObjectTracker threshold properties as dataclass constructor parameters
- ensure the compatibility defaults are restored during post-initialisation

## Testing
- python - <<'PY' ... (stub dependencies, instantiate ObjectTracker, verify property defaults)

------
https://chatgpt.com/codex/tasks/task_e_68cc249db220832eb7b7c738a58e128d