### PR TITLE
Refactor LLM client configuration handling

### DIFF
--- a/Server/app/config/app.json
+++ b/Server/app/config/app.json
@@ -36,6 +36,7 @@
     "threads": 2,
     "health_timeout": 5.0,
     "llm_base_url": "",
+    "llm_request_timeout": 30.0,
     "max_parallel_inference": 1
   }
 }

--- a/Server/core/llm/llm_client.py
+++ b/Server/core/llm/llm_client.py
@@ -1,22 +1,72 @@
-import os, requests
-from .persona import postprocess, TEMP, TOP_P, TOP_K, MAX_TOKENS
+"""HTTP client to interact with the local LLaMA REST API."""
 
-LLAMA_BASE = os.getenv("LLAMA_BASE", "http://127.0.0.1:8080")
+from __future__ import annotations
 
-def query_llm(messages, max_reply_chars: int = 220) -> str:
-    url = f"{LLAMA_BASE}/v1/chat/completions"
-    payload = {
-        "model": "local-llm",
-        "messages": messages,
-        "temperature": TEMP,
-        "top_p": TOP_P,
-        "top_k": TOP_K,
-        "max_tokens": MAX_TOKENS,
-        "repetition_penalty": 1.15,
-        "no_repeat_ngram_size": 3,
-        "stop": ["\n", "Usuario:", "Lumo:"],
-    }
-    r = requests.post(url, json=payload, timeout=30)
-    r.raise_for_status()
-    text = r.json()["choices"][0]["message"]["content"].strip()
-    return postprocess(text, max_reply_chars)
+import os
+from typing import Iterable, MutableMapping, Optional, Sequence
+
+import requests
+
+from .persona import MAX_TOKENS, TEMP, TOP_K, TOP_P, postprocess
+
+DEFAULT_BASE_URL = "http://127.0.0.1:8080"
+CHAT_ENDPOINT = "/v1/chat/completions"
+
+
+class LlamaClient:
+    """Small HTTP client specialised for the llama.cpp compatible API."""
+
+    def __init__(
+        self,
+        *,
+        base_url: Optional[str] = None,
+        request_timeout: Optional[float] = None,
+        model: str = "local-llm",
+        http_client: Optional[object] = None,
+        stop_sequences: Optional[Sequence[str]] = None,
+    ) -> None:
+        env_base = os.getenv("LLAMA_BASE", DEFAULT_BASE_URL)
+        chosen_base = base_url or env_base
+        self.base_url = chosen_base.rstrip("/") or DEFAULT_BASE_URL
+        self.request_timeout = 30.0 if request_timeout is None else float(request_timeout)
+        self.model = model
+        self._http = http_client or requests
+        self.stop_sequences: Sequence[str] = (
+            stop_sequences if stop_sequences is not None else ["\n", "Usuario:", "Lumo:"]
+        )
+
+    @property
+    def chat_url(self) -> str:
+        """Return the absolute URL used for chat completions."""
+
+        return f"{self.base_url}{CHAT_ENDPOINT}"
+
+    def build_payload(self, messages: Iterable[MutableMapping[str, str]]) -> MutableMapping[str, object]:
+        """Assemble the JSON payload for the llama.cpp REST endpoint."""
+
+        return {
+            "model": self.model,
+            "messages": list(messages),
+            "temperature": TEMP,
+            "top_p": TOP_P,
+            "top_k": TOP_K,
+            "max_tokens": MAX_TOKENS,
+            "repetition_penalty": 1.15,
+            "no_repeat_ngram_size": 3,
+            "stop": list(self.stop_sequences),
+        }
+
+    def query(self, messages: Sequence[MutableMapping[str, str]], *, max_reply_chars: int = 220) -> str:
+        """Execute a chat completion request and post-process the answer."""
+
+        payload = self.build_payload(messages)
+        response = self._http.post(self.chat_url, json=payload, timeout=self.request_timeout)
+        response.raise_for_status()
+        text = response.json()["choices"][0]["message"]["content"].strip()
+        return postprocess(text, max_reply_chars)
+
+
+def build_default_client() -> LlamaClient:
+    """Create a :class:`LlamaClient` instance using defaults and env fallbacks."""
+
+    return LlamaClient()

--- a/Server/core/llm/llm_to_tts.py
+++ b/Server/core/llm/llm_to_tts.py
@@ -1,8 +1,11 @@
+from __future__ import annotations
+
+import argparse
 import sys
 from pathlib import Path
-import argparse
+
 from persona import build_system
-from llm_client import query_llm
+from llm_client import LlamaClient
 from core.voice.tts import TextToSpeech
 
 THIS_DIR = Path(__file__).resolve().parent
@@ -21,13 +24,37 @@ def speak_text(text: str):
         print(f"[ERROR] TTS failed: {e}")
 
 # --- CLI ----------------------------------------------------------------------
-def main():
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Query the local LLM and speak the reply.")
+    parser.add_argument("prompt", help="Texto a enviar al modelo")
+    parser.add_argument(
+        "--base-url",
+        dest="base_url",
+        default=None,
+        help="URL base del servidor LLaMA (por defecto usa LLAMA_BASE o http://127.0.0.1:8080)",
+    )
+    parser.add_argument(
+        "--timeout",
+        dest="timeout",
+        type=float,
+        default=None,
+        help="Timeout de la petición en segundos (por defecto 30)",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    client = LlamaClient(base_url=args.base_url, request_timeout=args.timeout)
     system = build_system()
     messages = [
         {"role": "system", "content": system},
         {"role": "user", "content": args.prompt},
     ]
-    reply = query_llm(messages, max_reply_chars=MAX_REPLY_CHARS)
+    reply = client.query(messages, max_reply_chars=MAX_REPLY_CHARS)
     if not reply:
         print("[WARN] No reply from LLM.")
         return

--- a/Server/tests/test_llm_client.py
+++ b/Server/tests/test_llm_client.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+SERVER_ROOT = Path(__file__).resolve().parents[1]
+if str(SERVER_ROOT) not in sys.path:
+    sys.path.insert(0, str(SERVER_ROOT))
+
+core_stub = types.ModuleType("core")
+core_stub.__path__ = [str(SERVER_ROOT / "core")]
+sys.modules["core"] = core_stub
+
+requests_stub = types.ModuleType("requests")
+
+
+def _fail_post(*_args, **_kwargs):  # pragma: no cover - guardrail
+    raise AssertionError("Unexpected HTTP call during tests")
+
+
+requests_stub.post = _fail_post
+sys.modules["requests"] = requests_stub
+
+from core.llm.llm_client import CHAT_ENDPOINT, LlamaClient
+
+
+def test_llama_client_uses_env_base_when_not_provided(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LLAMA_BASE", "http://env.example:8080/")
+
+    client = LlamaClient()
+
+    assert client.base_url == "http://env.example:8080"
+    assert client.chat_url == f"http://env.example:8080{CHAT_ENDPOINT}"
+
+
+def test_llama_client_prefers_explicit_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LLAMA_BASE", "http://env.example:8080")
+
+    client = LlamaClient(base_url="http://override.local:9000/")
+
+    assert client.base_url == "http://override.local:9000"
+    assert client.chat_url == f"http://override.local:9000{CHAT_ENDPOINT}"
+
+
+def test_llama_client_query_uses_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("LLAMA_BASE", raising=False)
+
+    class DummyHTTP:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, float, dict]] = []
+
+        def post(self, url: str, json: dict, timeout: float):
+            self.calls.append((url, timeout, json))
+
+            class _Resp:
+                @staticmethod
+                def raise_for_status() -> None:
+                    return None
+
+                @staticmethod
+                def json() -> dict:
+                    return {"choices": [{"message": {"content": "hola"}}]}
+
+            return _Resp()
+
+    dummy_http = DummyHTTP()
+    client = LlamaClient(base_url="http://explicit.host", request_timeout=12.5, http_client=dummy_http)
+
+    reply = client.query([{"role": "user", "content": "hola"}], max_reply_chars=100)
+
+    assert reply == "hola"
+    assert dummy_http.calls[0][0] == f"http://explicit.host{CHAT_ENDPOINT}"
+    assert dummy_http.calls[0][1] == 12.5


### PR DESCRIPTION
## Summary
- replace the legacy LLaMA HTTP helper with a configurable `LlamaClient` that supports environment fallbacks and injectable HTTP backends
- allow the voice interface and `llm_to_tts` CLI to receive a client instance so deployments can override base URLs and request timeouts
- surface conversation configuration for LLM base URL/timeouts in the builder and cover the new behaviour with focused unit tests

## Testing
- `pytest` *(fails: optional GUI/hardware dependencies such as numpy.typing, spidev, mpu6050 are unavailable in the test environment)*
- `pytest Server/app/tests/test_builder_conversation.py Server/tests/test_llm_client.py`


------
https://chatgpt.com/codex/tasks/task_e_68d2b35f1f00832ea5620d36175e88e1