### PR TITLE
Refactor conversation manager with dependency injection

### DIFF
--- a/Server/core/VoiceInterface.py
+++ b/Server/core/VoiceInterface.py
@@ -1,18 +1,26 @@
-import time
-import threading
-import queue
+from __future__ import annotations
+
 import asyncio
-from pathlib import Path
+import logging
+import queue
+import threading
+import time
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass
+from typing import Any, Optional
 
 from LedController import LedController
+from core.hearing.stt import SpeechToText
 from core.llm.llm_client import LlamaClient, build_default_client
 from core.llm.llm_memory import ConversationMemory
 from core.llm.persona import build_system
 from core.voice.tts import TextToSpeech
-from core.hearing.stt import SpeechToText
+
+logger = logging.getLogger(__name__)
+
 
 mem = ConversationMemory(last_n=3)
-_default_llm_client = build_default_client()
+
 
 WAKE_WORDS = ["humo", "lo humo", "alumno", "lune", "lomo"]
 MAX_REPLY_CHARS = 220
@@ -21,194 +29,412 @@ SPEAK_COOLDOWN_SEC = 1.5
 ATTENTION_TTL_SEC = 15.0        # wake-up window (seconds)
 ATTN_BONUS_AFTER_SPEAK = 5.0    # extra after speaking to chain turns
 
-BASE = Path(__file__).resolve().parent
 
-# Instantiate engines once so they can be reused across calls
-_tts_engine = TextToSpeech()
-_stt_engine = SpeechToText()
-
-STT_PAUSED = False
-
-_loop = asyncio.new_event_loop()
-threading.Thread(target=_loop.run_forever, daemon=True).start()
-_ctrl = LedController(brightness=10, loop=_loop)
+LED_STATE_MAP = {
+    "WAKE": "wake",
+    "ATTENTIVE_LISTEN": "listen",
+    "THINK": "processing",
+    "SPEAK": "speaking",
+}
 
 
-async def _led_state(state: str):
-    if state == "wake":
-        await _ctrl.stop_animation()
-        await _ctrl.set_all([0, 128, 0])    
-    elif state == "listen":
-        await _ctrl.stop_animation()
-        await _ctrl.start_pulsed_wipe([0, 255, 0], 20)            
-    elif state == "processing":
-        await _ctrl.stop_animation()
-        await _ctrl.set_all([0, 0, 0])
-        await _ctrl.start_pulsed_wipe([0, 0, 128], 20)
-    elif state == "speaking":
-        await _ctrl.stop_animation()
-        await _ctrl.set_all([0, 0, 255])
-    else:
-        await _ctrl.stop_animation()
-        await _ctrl.set_all([0, 0, 0])
-
-def _submit(coro):
-    try:
-        asyncio.run_coroutine_threadsafe(coro, _loop)
-    except RuntimeError:
-        pass  # loop cerrado al apagar
-
-def leds_set(state: str) -> None:
-    print(f"[LEDS] {state}")  # TODO: integrate real LEDs
-    _submit(_led_state(state))
+class StopRequested(Exception):
+    """Raised internally when a shutdown signal is received."""
 
 
-def stt_pause() -> None:
-    global STT_PAUSED
-    STT_PAUSED = True
-    _stt_engine.pause()
+@dataclass
+class ConversationMetrics:
+    """Simple container to track timing metrics exposed through logging."""
+
+    llm_retry_count: int = 0
+    llm_calls: int = 0
+    llm_total_latency: float = 0.0
+    listen_started_at: Optional[float] = None
+    total_listen_time: float = 0.0
+
+    def start_listen(self, now: float) -> None:
+        if self.listen_started_at is None:
+            self.listen_started_at = now
+            logger.info("listen window started at %.3fs", now)
+
+    def stop_listen(self, now: float) -> None:
+        if self.listen_started_at is None:
+            return
+        elapsed = max(0.0, now - self.listen_started_at)
+        self.total_listen_time += elapsed
+        logger.info(
+            "listen window duration %.3fs (cumulative %.3fs)",
+            elapsed,
+            self.total_listen_time,
+        )
+        self.listen_started_at = None
+
+    def record_llm(self, latency: float, retries: int) -> None:
+        self.llm_calls += 1
+        self.llm_retry_count += retries
+        self.llm_total_latency += latency
+        avg = self.llm_total_latency / self.llm_calls if self.llm_calls else 0.0
+        logger.info(
+            "LLM call latency %.3fs, retries %d (total retries %d, avg latency %.3fs)",
+            latency,
+            retries,
+            self.llm_retry_count,
+            avg,
+        )
 
 
-def stt_resume() -> None:
-    global STT_PAUSED
-    STT_PAUSED = False
-    _stt_engine.resume()
+class STTService:
+    """Adapter around :class:`SpeechToText` providing a reusable generator."""
 
+    def __init__(self, engine: SpeechToText, *, queue_poll: float = 0.1) -> None:
+        self._engine = engine
+        self._queue_poll = queue_poll
 
-def stt_stop() -> None:
-    global STT_PAUSED
-    STT_PAUSED = True
-    _stt_engine.pause()
+    def stream(self) -> Iterator[Optional[str]]:
+        q: queue.Queue[Optional[str]] = queue.Queue()
 
+        def reader() -> None:
+            try:
+                for phrase in self._engine.listen():
+                    q.put(phrase)
+            finally:
+                q.put(None)
 
-def stt_stream():
-    """Yield utterances from the STT engine (drains queue when paused)."""
-    q: queue.Queue[str | None] = queue.Queue()
+        threading.Thread(target=reader, daemon=True).start()
 
-    def reader() -> None:
-        for phrase in _stt_engine.listen():
-            q.put(phrase)
-        q.put(None)
+        while True:
+            try:
+                item = q.get(timeout=self._queue_poll)
+            except queue.Empty:
+                yield None
+                continue
 
-    threading.Thread(target=reader, daemon=True).start()
-
-    while True:
-        if STT_PAUSED:
-            # drain any buffered phrases while paused
-            while True:
-                try:
-                    item = q.get_nowait()
-                    if item is None:
-                        return
-                except queue.Empty:
-                    break
-            time.sleep(0.02)
-            yield None
-            continue
-
-        try:
-            item = q.get(timeout=0.1)
             if item is None:
                 return
             yield item
-        except queue.Empty:
-            yield None
 
-def llm_ask(text: str, client: LlamaClient | None = None) -> str:
-    """Query the shared LLM client and return a brief Spanish reply."""
+    def pause(self) -> None:
+        self._engine.pause()
+
+    def resume(self) -> None:
+        self._engine.resume()
+
+    def stop(self) -> None:
+        self._engine.pause()
+
+
+class LedStateHandler:
+    """Thread-safe helper to drive :class:`LedController` animations."""
+
+    def __init__(
+        self,
+        controller: LedController,
+        loop: asyncio.AbstractEventLoop,
+        *,
+        loop_thread: Optional[threading.Thread] = None,
+    ) -> None:
+        self._controller = controller
+        self._loop = loop
+        self._loop_thread = loop_thread
+
+    def _submit(self, coro: asyncio.coroutines.Coroutine[Any, Any, Any]) -> None:
+        try:
+            asyncio.run_coroutine_threadsafe(coro, self._loop)
+        except RuntimeError:
+            logger.debug("LED loop no longer running")
+
+    async def _apply_state(self, state: str) -> None:
+        if state == "wake":
+            await self._controller.stop_animation()
+            await self._controller.set_all([0, 128, 0])
+        elif state == "listen":
+            await self._controller.stop_animation()
+            await self._controller.start_pulsed_wipe([0, 255, 0], 20)
+        elif state == "processing":
+            await self._controller.stop_animation()
+            await self._controller.set_all([0, 0, 0])
+            await self._controller.start_pulsed_wipe([0, 0, 128], 20)
+        elif state == "speaking":
+            await self._controller.stop_animation()
+            await self._controller.set_all([0, 0, 255])
+        else:
+            await self._controller.stop_animation()
+            await self._controller.set_all([0, 0, 0])
+
+    def set_state(self, state: str) -> None:
+        logger.debug("LED state -> %s", state)
+        self._submit(self._apply_state(state))
+
+    def close(self) -> None:
+        try:
+            fut = asyncio.run_coroutine_threadsafe(
+                self._controller.close(), self._loop
+            )
+            fut.result(timeout=2)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("Error closing LED controller: %s", exc)
+        finally:
+            self._loop.call_soon_threadsafe(self._loop.stop)
+            if self._loop_thread and self._loop_thread.is_alive():
+                self._loop_thread.join(timeout=1)
+
+
+def contains_wake_word(text: str) -> bool:
+    lowered = text.lower()
+    return any(w in lowered for w in WAKE_WORDS)
+
+
+def llm_ask(text: str, client: LlamaClient) -> str:
+    """Query the provided LLM client and return a brief Spanish reply."""
+
     system = build_system()
     msgs = mem.build_messages(system, text)
-    llm_client = client or _default_llm_client
-    reply = llm_client.query(msgs, max_reply_chars=220)
+    reply = client.query(msgs, max_reply_chars=MAX_REPLY_CHARS)
     mem.add_turn(text, reply)
     return reply
 
 
-def tts_say(text: str) -> int:
+def tts_say(text: str, tts: TextToSpeech) -> int:
     try:
-        _tts_engine.speak(text)
+        tts.speak(text)
         return 0
-    except Exception as e:
-        print(f"[ERROR] TTS failed: {e}")
+    except Exception as exc:  # pragma: no cover - hardware dependent
+        logger.error("TTS failed: %s", exc)
         return 1
 
 
-def contains_wake_word(text: str) -> bool:
-    t = text.lower()
-    return any(w in t for w in WAKE_WORDS)
-
 class ConversationManager:
-    def __init__(self, llm_client: LlamaClient | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        stt: STTService,
+        llm_client: LlamaClient,
+        tts: TextToSpeech,
+        led_controller: Any,
+        stop_event: threading.Event,
+        wait_until_ready: Callable[[], None],
+        additional_stop_events: Optional[Iterable[threading.Event]] = None,
+        llm_retry_max_attempts: int = 3,
+        llm_retry_initial_delay: float = 0.5,
+        llm_retry_backoff: float = 2.0,
+        llm_retry_max_delay: Optional[float] = None,
+        stt_poll_interval: float = 0.02,
+        speak_cooldown: float = SPEAK_COOLDOWN_SEC,
+    ) -> None:
         self.state = "NONE"
-        self.stt_iter = stt_stream()
+        self._stt = stt
+        self._stt_iter = stt.stream()
         self.pending = ""
-        self.reply = None
+        self.reply: Optional[str] = None
         self.last_speak_end = time.monotonic()
-        self.attentive_until = 0.0      # active attention window
+        self.attentive_until = 0.0
+        self.metrics = ConversationMetrics()
+
+        self._llm_client = llm_client
+        self._tts = tts
+        self._led = led_controller
+        self._stop_event = stop_event
+        self._extra_stop_events = tuple(additional_stop_events or ())
+        self._wait_until_ready = wait_until_ready
+
+        self._llm_retry_max_attempts = max(1, llm_retry_max_attempts)
+        self._llm_retry_initial_delay = max(0.0, llm_retry_initial_delay)
+        self._llm_retry_backoff = max(1.0, llm_retry_backoff)
+        self._llm_retry_max_delay = (
+            max(0.0, llm_retry_max_delay) if llm_retry_max_delay else None
+        )
+        self._poll_interval = max(0.0, stt_poll_interval)
+        self._poll_resolution = min(0.1, self._poll_interval or 0.02)
+        self._speak_cooldown = speak_cooldown
+
         self.set_state("WAKE")
-        self._llm_client = llm_client or _default_llm_client
+
+    # ------------------------------------------------------------------ helpers
+    def _should_stop(self) -> bool:
+        if self._stop_event.is_set():
+            return True
+        for ev in self._extra_stop_events:
+            if ev.is_set():
+                self._stop_event.set()
+                return True
+        return False
+
+    def _wait_with_stop(self, timeout: float) -> None:
+        if timeout <= 0:
+            if self._should_stop():
+                raise StopRequested
+            return
+
+        deadline = time.monotonic() + timeout
+        while True:
+            if self._should_stop():
+                raise StopRequested
+
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+
+            slice_timeout = min(remaining, self._poll_resolution)
+            if self._stop_event.wait(slice_timeout):
+                raise StopRequested
+
+    def _ensure_ready(self) -> None:
+        result: queue.Queue[Optional[BaseException]] = queue.Queue(maxsize=1)
+
+        def runner() -> None:
+            try:
+                self._wait_until_ready()
+                result.put(None)
+            except BaseException as exc:  # pragma: no cover - defensive
+                result.put(exc)
+
+        thread = threading.Thread(target=runner, daemon=True)
+        thread.start()
+
+        while True:
+            try:
+                exc = result.get(timeout=0.1)
+            except queue.Empty:
+                if self._should_stop():
+                    raise StopRequested
+                continue
+
+            if exc is None:
+                return
+            raise exc
+
+    def _poll_stt(self) -> Optional[str]:
+        try:
+            return next(self._stt_iter)
+        except StopIteration:
+            logger.debug("STT stream exhausted, recreating")
+            self._stt.resume()
+            self._stt_iter = self._stt.stream()
+            return None
+
+    def _set_led_state(self, state: str) -> None:
+        mapped = LED_STATE_MAP.get(state, "off")
+        if hasattr(self._led, "set_state"):
+            try:
+                self._led.set_state(mapped)
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.debug("LED set_state failed: %s", exc)
 
     def set_state(self, new_state: str) -> None:
-        if self.state != new_state:
-            print(f"[STATE] -> {new_state}")
-            if new_state == "WAKE":
-                leds_set("wake")
-            elif new_state == "ATTENTIVE_LISTEN":
-                leds_set("listen")
-            elif new_state == "THINK":
-                leds_set("processing")
-            elif new_state == "SPEAK":
-                leds_set("speaking")
-            self.state = new_state
+        if self.state == new_state:
+            return
+        logger.info("state transition %s -> %s", self.state, new_state)
+        self.state = new_state
+        self._set_led_state(new_state)
 
-    def run(self) -> None:
+    def _query_llm(self, text: str) -> str:
+        delay = self._llm_retry_initial_delay
+        attempt = 0
+        retries_for_call = 0
+
+        while attempt < self._llm_retry_max_attempts:
+            attempt += 1
+            start = time.perf_counter()
+            try:
+                reply = llm_ask(text, self._llm_client)
+            except Exception as exc:
+                logger.warning(
+                    "LLM error attempt %d/%d: %s",
+                    attempt,
+                    self._llm_retry_max_attempts,
+                    exc,
+                )
+
+                if attempt >= self._llm_retry_max_attempts:
+                    logger.error("LLM failed after %d attempts", attempt)
+                    raise
+
+                retries_for_call += 1
+
+                wait_time = delay
+                if self._llm_retry_max_delay is not None:
+                    wait_time = min(wait_time, self._llm_retry_max_delay)
+
+                self._wait_with_stop(wait_time)
+                delay *= self._llm_retry_backoff
+                continue
+
+            latency = time.perf_counter() - start
+            self.metrics.record_llm(latency, retries_for_call)
+            return reply
+
+        raise RuntimeError("LLM retry configuration invalid")
+
+    def _cleanup(self) -> None:
+        now = time.monotonic()
+        self.metrics.stop_listen(now)
         try:
-            while True:
-                try:
-                    utter = next(self.stt_iter)
-                except StopIteration:
-                    stt_resume()
-                    self.stt_iter = stt_stream()
-                    time.sleep(0.02)
-                    continue
+            self._stt.stop()
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("Error stopping STT: %s", exc)
 
+        if hasattr(self._led, "set_state"):
+            try:
+                self._led.set_state("off")
+            except Exception:  # pragma: no cover - defensive
+                pass
+
+        if hasattr(self._led, "close"):
+            try:
+                self._led.close()
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.debug("Error closing LED handler: %s", exc)
+
+    # --------------------------------------------------------------------- main
+    def run(self) -> None:
+        logger.info("Conversation manager starting")
+        try:
+            self._ensure_ready()
+
+            while True:
+                if self._should_stop():
+                    raise StopRequested
+
+                utter = self._poll_stt()
                 now = time.monotonic()
 
                 if self.state == "WAKE":
                     if utter:
-                        print(f"[HEARD] {utter}")
+                        logger.info("heard: %s", utter)
                         if contains_wake_word(utter):
-                            print("[WAKE] wakeword detected → attentive mode")
+                            logger.info("wake word detected → attentive mode")
                             self.attentive_until = now + ATTENTION_TTL_SEC
+                            self.metrics.start_listen(now)
                             self.set_state("ATTENTIVE_LISTEN")
 
                 elif self.state == "ATTENTIVE_LISTEN":
-                    # expire window if no interaction
                     if now > self.attentive_until:
-                        print("[ATTN] attention expired → WAKE")
+                        logger.info("attention expired → WAKE")
+                        self.metrics.stop_listen(now)
                         self.set_state("WAKE")
                     elif utter:
-                        print(f"[CMD] {utter}")
+                        logger.info("command: %s", utter)
                         self.pending = utter
-                        self.attentive_until = (
-                            now + ATTENTION_TTL_SEC
-                        )  # renew attention
-                        stt_pause()
+                        self.attentive_until = now + ATTENTION_TTL_SEC
+                        self.metrics.stop_listen(now)
+                        self._stt.pause()
                         self.set_state("THINK")
 
                 elif self.state == "THINK":
                     try:
-                        self.reply = llm_ask(self.pending, client=self._llm_client)
+                        self.reply = self._query_llm(self.pending)
                         self.set_state("SPEAK")
-                    except Exception as e:
-                        print(f"[THINK ERROR] {e}")
-                        stt_resume()
+                    except StopRequested:
+                        raise
+                    except Exception as exc:
+                        logger.error("LLM processing failed: %s", exc)
+                        self._stt.resume()
                         self.set_state("WAKE")
 
                 elif self.state == "SPEAK":
                     if self.reply is not None:
-                        print(f"[SAY] {self.reply}")
-                        tts_say(self.reply)
+                        logger.info("reply: %s", self.reply)
+                        tts_say(self.reply, self._tts)
                         self.reply = None
                         self.last_speak_end = time.monotonic()
                         self.attentive_until = (
@@ -217,20 +443,55 @@ class ConversationManager:
                             + ATTN_BONUS_AFTER_SPEAK
                         )
 
-                    if time.monotonic() - self.last_speak_end >= SPEAK_COOLDOWN_SEC:
-                        stt_resume()
+                    if time.monotonic() - self.last_speak_end >= self._speak_cooldown:
+                        self._stt.resume()
+                        now = time.monotonic()
+                        self.metrics.start_listen(now)
                         self.set_state("ATTENTIVE_LISTEN")
 
-                time.sleep(0.02)
+                self._wait_with_stop(self._poll_interval)
 
-        except KeyboardInterrupt:
-            pass
+        except StopRequested:
+            logger.info("Stop requested, shutting down conversation manager")
+        except Exception:
+            logger.exception("Conversation manager crashed")
+            raise
         finally:
-            stt_stop()
-            try:
-                _submit(_ctrl.close())
-            finally:
-                _loop.call_soon_threadsafe(_loop.stop)
+            self._cleanup()
 
-if __name__ == "__main__":
-    ConversationManager().run()
+
+def build_default_conversation_manager(
+    *,
+    stop_event: Optional[threading.Event] = None,
+    additional_stop_events: Optional[Iterable[threading.Event]] = None,
+) -> ConversationManager:
+    """Helper to build a :class:`ConversationManager` with default engines."""
+
+    stop = stop_event or threading.Event()
+
+    stt_engine = SpeechToText()
+    stt_service = STTService(stt_engine)
+    tts_engine = TextToSpeech()
+    llm_client = build_default_client()
+
+    loop = asyncio.new_event_loop()
+    loop_thread = threading.Thread(target=loop.run_forever, daemon=True)
+    loop_thread.start()
+    led_ctrl = LedController(brightness=10, loop=loop)
+    led_handler = LedStateHandler(led_ctrl, loop, loop_thread=loop_thread)
+
+    return ConversationManager(
+        stt=stt_service,
+        llm_client=llm_client,
+        tts=tts_engine,
+        led_controller=led_handler,
+        stop_event=stop,
+        additional_stop_events=additional_stop_events,
+        wait_until_ready=lambda: None,
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution only
+    logging.basicConfig(level=logging.INFO)
+    manager = build_default_conversation_manager()
+    manager.run()

--- a/Server/tests/test_conversation_manager.py
+++ b/Server/tests/test_conversation_manager.py
@@ -1,0 +1,213 @@
+import sys
+import threading
+import time
+import types
+from pathlib import Path
+
+SERVER_ROOT = Path(__file__).resolve().parents[1]
+if str(SERVER_ROOT) not in sys.path:
+    sys.path.insert(0, str(SERVER_ROOT))
+
+core_stub = types.ModuleType("core")
+core_stub.__path__ = [str(SERVER_ROOT / "core")]
+sys.modules["core"] = core_stub
+
+led_stub = types.ModuleType("LedController")
+
+
+class _StubLedController:
+    async def stop_animation(self):  # pragma: no cover - defensive shim
+        pass
+
+    async def set_all(self, _color):  # pragma: no cover - defensive shim
+        pass
+
+    async def start_pulsed_wipe(self, _color, _wait, *_args):  # pragma: no cover
+        pass
+
+    async def close(self):  # pragma: no cover - defensive shim
+        pass
+
+
+led_stub.LedController = _StubLedController
+sys.modules["LedController"] = led_stub
+
+sounddevice_stub = types.ModuleType("sounddevice")
+
+
+class _StubStream:  # pragma: no cover - defensive shim
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+sounddevice_stub.RawInputStream = _StubStream
+sys.modules["sounddevice"] = sounddevice_stub
+
+vosk_stub = types.ModuleType("vosk")
+
+
+class _StubModel:  # pragma: no cover - defensive shim
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+class _StubRecognizer:  # pragma: no cover - defensive shim
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def SetWords(self, *_args, **_kwargs):
+        pass
+
+
+vosk_stub.Model = _StubModel
+vosk_stub.KaldiRecognizer = _StubRecognizer
+sys.modules["vosk"] = vosk_stub
+
+requests_stub = types.ModuleType("requests")
+
+
+def _fail_post(*_args, **_kwargs):  # pragma: no cover - guardrail
+    raise AssertionError("Unexpected HTTP call during tests")
+
+
+requests_stub.post = _fail_post
+sys.modules["requests"] = requests_stub
+
+from core.VoiceInterface import ConversationManager
+
+
+class FakeSTT:
+    def __init__(self, utterances):
+        self.utterances = list(utterances)
+        self.pause_calls = 0
+        self.resume_calls = 0
+        self.stopped = False
+
+    def stream(self):
+        for item in self.utterances:
+            yield item
+        while True:
+            yield None
+
+    def pause(self):
+        self.pause_calls += 1
+
+    def resume(self):
+        self.resume_calls += 1
+
+    def stop(self):
+        self.stopped = True
+
+
+class FakeLLM:
+    def __init__(self, failures, reply="respuesta"):
+        self.failures = failures
+        self.reply = reply
+        self.calls = 0
+        self.call_times = []
+        self.call_event = threading.Event()
+
+    def query(self, messages, max_reply_chars=220):
+        self.calls += 1
+        self.call_times.append(time.monotonic())
+        self.call_event.set()
+        if self.calls <= self.failures:
+            raise TimeoutError("timeout")
+        return self.reply
+
+
+class FakeTTS:
+    def __init__(self):
+        self.phrases = []
+        self.event = threading.Event()
+
+    def speak(self, text):
+        self.phrases.append(text)
+        self.event.set()
+
+
+class FakeLED:
+    def __init__(self):
+        self.states = []
+        self.closed = False
+
+    def set_state(self, state):
+        self.states.append(state)
+
+    def close(self):
+        self.closed = True
+def test_llm_backoff_retries_and_metrics():
+    stt = FakeSTT(["humo", "hola"])
+    llm = FakeLLM(2, reply="ok")
+    tts = FakeTTS()
+    led = FakeLED()
+    stop_event = threading.Event()
+
+    manager = ConversationManager(
+        stt=stt,
+        llm_client=llm,
+        tts=tts,
+        led_controller=led,
+        stop_event=stop_event,
+        wait_until_ready=lambda: None,
+        stt_poll_interval=0.01,
+        llm_retry_initial_delay=0.01,
+        llm_retry_backoff=2.0,
+        llm_retry_max_attempts=5,
+        speak_cooldown=0.0,
+    )
+
+    thread = threading.Thread(target=manager.run, daemon=True)
+    thread.start()
+
+    assert tts.event.wait(3)
+    stop_event.set()
+    thread.join(3)
+
+    assert llm.calls == 3
+    assert manager.metrics.llm_retry_count == 2
+    assert manager.metrics.llm_calls == 1
+    assert stt.pause_calls >= 1
+    assert stt.resume_calls >= 1
+
+    diffs = [b - a for a, b in zip(llm.call_times, llm.call_times[1:])]
+    assert diffs[0] >= 0.01
+    assert diffs[1] >= 0.02
+
+
+def test_backoff_respects_stop_event():
+    stt = FakeSTT(["humo", "hola"])
+    llm = FakeLLM(10)
+    tts = FakeTTS()
+    led = FakeLED()
+    stop_event = threading.Event()
+
+    manager = ConversationManager(
+        stt=stt,
+        llm_client=llm,
+        tts=tts,
+        led_controller=led,
+        stop_event=stop_event,
+        wait_until_ready=lambda: None,
+        stt_poll_interval=0.01,
+        llm_retry_initial_delay=0.1,
+        llm_retry_backoff=2.0,
+        llm_retry_max_attempts=10,
+        speak_cooldown=0.0,
+    )
+
+    thread = threading.Thread(target=manager.run, daemon=True)
+    thread.start()
+
+    assert llm.call_event.wait(2)
+    stop_event.set()
+    thread.join(2)
+    assert not thread.is_alive()
+    assert stt.stopped
+


### PR DESCRIPTION
## Summary
- rewrite `ConversationManager` to receive explicit dependencies, add LED state handler, metrics, and configurable exponential backoff around LLM failures
- replace global engine singletons with injectable services and helper builders while switching busy sleeps to event-based waits
- add pytest coverage that simulates LLM timeouts and ensures retries respect stop events

## Testing
- pytest Server/tests

------
https://chatgpt.com/codex/tasks/task_e_68d2c5ad95f4832ea5ad18ac739d9542