### PR TITLE
Add callbacks to social FSM and tests

### DIFF
--- a/Server/app/controllers/social_fsm.py
+++ b/Server/app/controllers/social_fsm.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Dict, List, Optional
+from typing import Callable, Dict, List, Optional
 import logging
 import time
 import random
@@ -14,7 +14,13 @@ from core.voice.sfx import play_sound
 class SocialFSM:
     """Simple social finite state machine based on face alignment."""
 
-    def __init__(self, vision: VisionService, movement: MovementService, cfg: dict | None = None) -> None:
+    def __init__(
+        self,
+        vision: VisionService,
+        movement: MovementService,
+        cfg: dict | None = None,
+        callbacks: Optional[Dict[str, Callable[["SocialFSM"], None]]] = None,
+    ) -> None:
         cfg = cfg or {}
         behavior_cfg = cfg.get("behavior", {}).get("social_fsm", {})
         self.deadband_x = float(behavior_cfg.get("deadband_x", 0.12))
@@ -49,16 +55,30 @@ class SocialFSM:
         self.logger = logging.getLogger("social_fsm")
         self.audio = None
         self._drift_until = None
+        callbacks = dict(callbacks or {})
+        self._callbacks: Dict[str, Callable[["SocialFSM"], None]] = {}
+        for name in ("on_interact", "on_exit_interact"):
+            cb = callbacks.get(name)
+            if callable(cb):
+                self._callbacks[name] = cb
+        disable_default = bool(callbacks.get("disable_default_interact"))
+        self._default_interact_enabled = not disable_default
+        if "on_interact" not in self._callbacks:
+            self._default_interact_enabled = True
 
     def _set_state(self, new_state: str) -> None:
         if new_state == self.state:
             return
         self.logger.info("leaving %s", self.state)
+        if self.state == "INTERACT":
+            self._run_callback("on_exit_interact")
         self.state = new_state
         self.logger.info("entering %s", self.state)
         if new_state == "INTERACT":
             self.interact_until = time.monotonic() + self.interact_ms / 1000.0
-            self._on_interact()
+            self._run_callback("on_interact")
+            if self._default_interact_enabled:
+                self._on_interact()
         if new_state != "INTERACT":
             self.lock_frames = 0
             self._drift_until = None
@@ -147,3 +167,12 @@ class SocialFSM:
             logging.info("meow")
         delay = random.uniform(self.meow_cooldown_min, self.meow_cooldown_max)
         self._next_meow_time = now + delay
+
+    def _run_callback(self, name: str) -> None:
+        callback = self._callbacks.get(name)
+        if not callback:
+            return
+        try:
+            callback(self)
+        except Exception:
+            self.logger.exception("error running %s callback", name)

--- a/Server/tests/test_social_fsm.py
+++ b/Server/tests/test_social_fsm.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+import types
+from unittest.mock import Mock
+
+import pytest
+
+SERVER_ROOT = Path(__file__).resolve().parents[1]
+if str(SERVER_ROOT) not in sys.path:
+    sys.path.insert(0, str(SERVER_ROOT))
+
+cv2_stub = types.ModuleType("cv2")
+cv2_stub.setNumThreads = lambda *args, **kwargs: None  # pragma: no cover - test stub
+sys.modules.setdefault("cv2", cv2_stub)
+
+core_stub = types.ModuleType("core")
+core_stub.__path__ = []  # pragma: no cover - namespace stub
+sys.modules.setdefault("core", core_stub)
+
+vision_package = types.ModuleType("core.vision")
+vision_package.__path__ = []  # pragma: no cover - namespace stub
+sys.modules.setdefault("core.vision", vision_package)
+
+voice_package = types.ModuleType("core.voice")
+voice_package.__path__ = []  # pragma: no cover - namespace stub
+sys.modules.setdefault("core.voice", voice_package)
+
+voice_sfx_module = types.ModuleType("core.voice.sfx")
+voice_sfx_module.play_sound = lambda *args, **kwargs: None
+sys.modules.setdefault("core.voice.sfx", voice_sfx_module)
+
+movement_control_module = types.ModuleType("core.MovementControl")
+
+
+class _StubMovementControl:  # pragma: no cover - test stub
+    head_limits = (-10.0, 10.0, 0.0)
+
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+    def start_loop(self) -> None:
+        pass
+
+    def stop(self) -> None:
+        pass
+
+    def relax(self) -> None:
+        pass
+
+    def turn_left(self, *args, **kwargs) -> None:
+        pass
+
+    def turn_right(self, *args, **kwargs) -> None:
+        pass
+
+    def head_deg(self, *args, **kwargs) -> None:
+        pass
+
+
+movement_control_module.MovementControl = _StubMovementControl
+sys.modules.setdefault("core.MovementControl", movement_control_module)
+
+vision_manager_module = types.ModuleType("core.VisionManager")
+
+
+class _StubVisionManager:  # pragma: no cover - test stub
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+    def start(self) -> None:
+        pass
+
+    def start_stream(self, *args, **kwargs) -> None:
+        pass
+
+    def stop(self) -> None:
+        pass
+
+    def select_pipeline(self, *args, **kwargs) -> None:
+        pass
+
+    def get_last_processed_encoded(self):
+        return None
+
+    def snapshot(self):
+        return None
+
+
+vision_manager_module.VisionManager = _StubVisionManager
+sys.modules.setdefault("core.VisionManager", vision_manager_module)
+
+profile_manager_module = types.ModuleType("core.vision.profile_manager")
+profile_manager_module._profiles = {}
+sys.modules.setdefault("core.vision.profile_manager", profile_manager_module)
+
+vision_api_module = types.ModuleType("core.vision.api")
+vision_api_module.register_pipeline = lambda *args, **kwargs: None
+sys.modules.setdefault("core.vision.api", vision_api_module)
+
+face_pipeline_module = types.ModuleType("core.vision.pipeline.face_pipeline")
+
+
+class _StubFacePipeline:  # pragma: no cover - test stub
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+
+face_pipeline_module.FacePipeline = _StubFacePipeline
+sys.modules.setdefault("core.vision.pipeline.face_pipeline", face_pipeline_module)
+
+control_pid_module = types.ModuleType("control.pid")
+
+
+class _StubPID:  # pragma: no cover - test stub
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+    def PID_compute(self, *args, **kwargs) -> float:
+        return 0.0
+
+
+control_pid_module.Incremental_PID = _StubPID
+sys.modules.setdefault("control.pid", control_pid_module)
+
+from app.controllers import social_fsm
+
+
+class _DummyTracker:
+    def __init__(self) -> None:
+        self.deadband_x = 0.0
+        self.lock_frames_needed = 0
+        self.miss_release = 0
+        self.recenter_after = 0
+
+    def update(self, *_: object, **__: object) -> None:  # pragma: no cover - helper
+        return
+
+
+def _make_fsm(monkeypatch: pytest.MonkeyPatch, callbacks: dict | None = None) -> social_fsm.SocialFSM:
+    tracker = _DummyTracker()
+    monkeypatch.setattr(social_fsm, "FaceTracker", lambda *args, **kwargs: tracker)
+    movement = SimpleNamespace(mc=object(), relax=Mock(), stop=Mock())
+    vision = SimpleNamespace(vm=object())
+    fsm = social_fsm.SocialFSM(vision, movement, callbacks=callbacks)
+    monkeypatch.setattr(fsm, "_on_interact", Mock())
+    return fsm
+
+
+def test_interact_callback_invoked_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    on_interact = Mock()
+    on_exit = Mock()
+    fsm = _make_fsm(
+        monkeypatch,
+        callbacks={
+            "on_interact": on_interact,
+            "on_exit_interact": on_exit,
+            "disable_default_interact": True,
+        },
+    )
+
+    fsm._set_state("INTERACT")
+    fsm._set_state("INTERACT")
+    fsm._set_state("IDLE")
+
+    assert on_interact.call_count == 1
+    assert on_exit.call_count == 1
+    assert fsm._on_interact.call_count == 0
+
+
+def test_interact_callback_exception_logged(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    error = RuntimeError("boom")
+
+    def failing_callback(_: social_fsm.SocialFSM) -> None:
+        raise error
+
+    fsm = _make_fsm(
+        monkeypatch,
+        callbacks={
+            "on_interact": failing_callback,
+            "disable_default_interact": True,
+        },
+    )
+
+    with caplog.at_level(logging.ERROR, logger="social_fsm"):
+        fsm._set_state("INTERACT")
+
+    assert fsm.state == "INTERACT"
+    assert fsm._on_interact.call_count == 0
+    assert any(record.exc_info for record in caplog.records)


### PR DESCRIPTION
## Summary
- allow SocialFSM to accept optional callbacks for entering and exiting the INTERACT state
- invoke callbacks safely while keeping the default meow behavior configurable
- add unit tests covering callback invocation and error logging

## Testing
- pytest Server/tests

------
https://chatgpt.com/codex/tasks/task_e_68d2cb1a8764832eb73b5f981922abc0