### PR TITLE
Build conversation service in app builder

### DIFF
--- a/Server/app/services/conversation_service.py
+++ b/Server/app/services/conversation_service.py
@@ -52,6 +52,12 @@ class ConversationService:
         self._stop_event = threading.Event()
         self._lock = threading.Lock()
 
+    @property
+    def stop_event(self) -> threading.Event:
+        """Expose the internal stop event for dependency wiring."""
+
+        return self._stop_event
+
     # ------------------------------------------------------------------
     def start(self) -> None:
         """Inicia el servicio si no se encuentra en ejecución."""

--- a/Server/app/tests/test_builder_conversation.py
+++ b/Server/app/tests/test_builder_conversation.py
@@ -1,7 +1,10 @@
 import json
+import os
 import sys
 import types
 from pathlib import Path
+from typing import Any, Dict
+from unittest import mock
 
 import pytest
 
@@ -28,6 +31,11 @@ numpy_stub.ndarray = object
 numpy_stub.float32 = float
 numpy_stub.uint8 = int
 sys.modules.setdefault("numpy", numpy_stub)
+numpy_typing_stub = types.ModuleType("numpy.typing")
+numpy_typing_stub.NDArray = object
+sys.modules.setdefault("numpy.typing", numpy_typing_stub)
+
+from app.services.conversation_service import ConversationService
 
 from app.builder import build
 
@@ -36,6 +44,91 @@ def write_config(tmp_path: Path, data: dict) -> Path:
     config_path = tmp_path / "config.json"
     config_path.write_text(json.dumps(data))
     return config_path
+
+
+def install_conversation_stubs(monkeypatch: pytest.MonkeyPatch) -> Dict[str, Any]:
+    created: Dict[str, Any] = {}
+
+    class DummyLLMClient:
+        def __init__(
+            self, *, base_url: str | None = None, request_timeout: float | None = None
+        ) -> None:
+            env_base = os.getenv("LLAMA_BASE", "http://127.0.0.1:8080")
+            chosen = base_url or env_base
+            self.base_url = str(chosen).rstrip("/")
+            self.request_timeout = 30.0 if request_timeout is None else request_timeout
+
+    def fake_llm_client(cfg: Dict[str, Any]) -> DummyLLMClient:
+        client = DummyLLMClient(
+            base_url=cfg.get("llm_base_url") or None,
+            request_timeout=cfg.get("llm_request_timeout"),
+        )
+        created["llm_client"] = client
+        created["llm_cfg"] = cfg
+        return client
+
+    class DummyProcess:
+        def __init__(self, cfg: Dict[str, Any]) -> None:
+            self.cfg = dict(cfg)
+
+    def fake_process(cfg: Dict[str, Any]) -> DummyProcess:
+        process = DummyProcess(cfg)
+        created["process"] = process
+        return process
+
+    class DummySTT:
+        pass
+
+    def fake_stt(_cfg: Dict[str, Any]) -> DummySTT:
+        stt = DummySTT()
+        created["stt"] = stt
+        return stt
+
+    class DummyTTS:
+        pass
+
+    def fake_tts(_cfg: Dict[str, Any]) -> DummyTTS:
+        tts = DummyTTS()
+        created["tts"] = tts
+        return tts
+
+    class DummyLED:
+        pass
+
+    def fake_led(_cfg: Dict[str, Any]):
+        led = DummyLED()
+        created["led"] = led
+        return led, None, None
+
+    def fake_manager_factory():
+        holder: Dict[str, Any] = {}
+
+        def register(event: Any) -> None:
+            holder["stop_event"] = event
+            created["registered_stop_event"] = event
+
+        def factory(**kwargs: Any) -> Any:
+            created["manager_factory_kwargs"] = kwargs
+            manager = types.SimpleNamespace(**kwargs)
+            manager.stop_event = holder.get("stop_event")
+            manager.run = lambda: None
+            manager.pause_stt = lambda: None
+            manager.drain_queues = lambda: None
+            manager.request_stop = lambda: None
+            manager.stop = lambda: None
+            return manager
+
+        manager_kwargs = {"wait_until_ready": lambda: None}
+        return factory, manager_kwargs, register
+
+    monkeypatch.setattr("app.builder._build_conversation_llm_client", fake_llm_client)
+    monkeypatch.setattr("app.builder._build_conversation_process", fake_process)
+    monkeypatch.setattr("app.builder._build_conversation_stt_service", fake_stt)
+    monkeypatch.setattr("app.builder._build_conversation_tts", fake_tts)
+    monkeypatch.setattr("app.builder._build_conversation_led_handler", fake_led)
+    monkeypatch.setattr("app.builder._build_conversation_manager_factory", fake_manager_factory)
+
+    return created
 
 
 def test_conversation_defaults_when_missing_section(tmp_path: Path) -> None:
@@ -51,6 +144,7 @@ def test_conversation_defaults_when_missing_section(tmp_path: Path) -> None:
 
     assert services.enable_conversation is False
     assert services.conversation_disabled_reason is None
+    assert services.conversation is None
     assert services.conversation_cfg == {
         "enable": False,
         "llama_binary": "",
@@ -107,9 +201,13 @@ def test_conversation_disabled_when_required_paths_missing(tmp_path: Path, caplo
     assert services.conversation_disabled_reason is not None
     assert "llama_binary" in services.conversation_disabled_reason
     assert any("llama_binary" in record.message for record in caplog.records)
+    assert services.conversation is None
 
 
-def test_conversation_client_uses_configured_url_and_timeout(tmp_path: Path) -> None:
+def test_conversation_client_uses_configured_url_and_timeout(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    stubs = install_conversation_stubs(monkeypatch)
     config_path = write_config(
         tmp_path,
         {
@@ -132,12 +230,14 @@ def test_conversation_client_uses_configured_url_and_timeout(tmp_path: Path) -> 
     services = build(str(config_path))
 
     assert services.enable_conversation is True
-    assert services.conversation is not None
-    assert services.conversation.base_url == "http://configured:8080"
-    assert services.conversation.request_timeout == 12.5
+    assert isinstance(services.conversation, ConversationService)
+    assert stubs["llm_client"].base_url == "http://configured:8080"
+    assert stubs["llm_client"].request_timeout == 12.5
+    assert stubs["registered_stop_event"] is services.conversation.stop_event
 
 
 def test_conversation_client_falls_back_to_env_base(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    stubs = install_conversation_stubs(monkeypatch)
     monkeypatch.setenv("LLAMA_BASE", "http://env-base:9000")
     config_path = write_config(
         tmp_path,
@@ -160,6 +260,76 @@ def test_conversation_client_falls_back_to_env_base(monkeypatch: pytest.MonkeyPa
     services = build(str(config_path))
 
     assert services.enable_conversation is True
-    assert services.conversation is not None
-    assert services.conversation.base_url == "http://env-base:9000"
-    assert services.conversation.request_timeout == 30.0
+    assert isinstance(services.conversation, ConversationService)
+    assert stubs["llm_client"].base_url == "http://env-base:9000"
+    assert stubs["llm_client"].request_timeout == 30.0
+    assert stubs["registered_stop_event"] is services.conversation.stop_event
+
+
+def test_social_fsm_registers_conversation_callbacks(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    stubs = install_conversation_stubs(monkeypatch)
+
+    class DummyVision:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            self.args = args
+            self.kwargs = kwargs
+
+        def register_face_pipeline(self, _profile: str) -> None:
+            return None
+
+    class DummyMovement:
+        def __init__(self) -> None:
+            self.started = True
+
+    class DummyFSM:
+        def __init__(self, _vision, _movement, _cfg, callbacks=None) -> None:
+            self.callbacks = dict(callbacks or {})
+
+    vision_module = types.ModuleType("app.services.vision_service")
+    vision_module.VisionService = DummyVision
+    monkeypatch.setitem(sys.modules, "app.services.vision_service", vision_module)
+
+    movement_module = types.ModuleType("app.services.movement_service")
+    movement_module.MovementService = DummyMovement
+    monkeypatch.setitem(sys.modules, "app.services.movement_service", movement_module)
+
+    social_module = types.ModuleType("app.controllers.social_fsm")
+    social_module.SocialFSM = DummyFSM
+    monkeypatch.setitem(sys.modules, "app.controllers.social_fsm", social_module)
+
+    config_path = write_config(
+        tmp_path,
+        {
+            "enable_vision": True,
+            "enable_movement": True,
+            "conversation": {
+                "enable": True,
+                "llama_binary": "/bin/llama",
+                "model_path": "/models/model.gguf",
+                "port": 8088,
+                "threads": 4,
+                "health_timeout": 6.5,
+            },
+        },
+    )
+
+    services = build(str(config_path))
+
+    assert isinstance(services.conversation, ConversationService)
+    assert isinstance(services.fsm, DummyFSM)
+    assert "on_interact" in services.fsm.callbacks
+    assert "on_exit_interact" in services.fsm.callbacks
+
+    start_mock = mock.Mock()
+    stop_mock = mock.Mock()
+    monkeypatch.setattr(services.conversation, "start", start_mock)
+    monkeypatch.setattr(services.conversation, "stop", stop_mock)
+
+    services.fsm.callbacks["on_interact"](services.fsm)
+    start_mock.assert_called_once_with()
+    services.fsm.callbacks["on_exit_interact"](services.fsm)
+    stop_mock.assert_called_once_with()
+
+    assert stubs["registered_stop_event"] is services.conversation.stop_event


### PR DESCRIPTION
## Summary
- build `ConversationService` in the app builder using configured LLM client, `LlamaServerProcess`, and voice/LED wrappers
- expose the conversation stop event and wire SocialFSM callbacks to start and stop the service when entering/exiting INTERACT
- update builder tests to cover enabled/disabled conversation scenarios and callback registration with stubbed dependencies

## Testing
- `pytest Server/app/tests`


------
https://chatgpt.com/codex/tasks/task_e_68d38a13f88c832e9bf82ee178f433cf