### PR TITLE
Ensure AppRuntime coordinates conversation lifecycle

### DIFF
--- a/Server/app/runtime.py
+++ b/Server/app/runtime.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import signal
 import threading
 import time
@@ -7,7 +8,7 @@ from types import FrameType
 from typing import Any, Callable, Dict, Optional
 
 from .builder import AppServices
-from network.ws_server import start_ws_server
+from network import ws_server
 
 
 class AppRuntime:
@@ -19,6 +20,9 @@ class AppRuntime:
         self._frame_handler: Optional[Callable[[Dict[str, Any] | None], None]] = None
         self._shutdown_event = threading.Event()
         self._running = False
+        self._stop_lock = threading.Lock()
+        self._stop_completed = False
+        self._ws_thread: Optional[threading.Thread] = None
         self._register_signal_handlers()
 
     @property
@@ -83,10 +87,13 @@ class AppRuntime:
             return
 
         self._shutdown_event.clear()
+        with self._stop_lock:
+            self._stop_completed = False
         self._running = True
 
         vision = self.svcs.vision if self.svcs.vision else None
         movement = self.svcs.movement if self.svcs.movement else None
+        conversation = self.svcs.conversation if self.svcs.conversation else None
 
         if movement and self.svcs.enable_movement:
             movement.start()
@@ -108,12 +115,17 @@ class AppRuntime:
                 )
                 vision_started = True
 
+            if conversation and self.svcs.enable_conversation:
+                conversation.start()
+
             if self.svcs.enable_ws and vision:
                 ws_cfg = self.svcs.ws_cfg or {}
                 host = ws_cfg.get("host", "0.0.0.0")
                 port = int(ws_cfg.get("port", 8765))
+                self._start_ws_server(vision, host=host, port=port)
                 try:
-                    start_ws_server(vision, host=host, port=port)
+                    while not self._shutdown_event.wait(timeout=0.5):
+                        pass
                 except KeyboardInterrupt:
                     pass
             elif vision_started:
@@ -126,14 +138,41 @@ class AppRuntime:
             self.stop()
 
     def stop(self) -> None:
-        if not self._running:
-            self._shutdown_event.set()
-        else:
-            self._running = False
-            self._shutdown_event.set()
-
         vision = self.svcs.vision if self.svcs.vision else None
         movement = self.svcs.movement if self.svcs.movement else None
+        conversation = self.svcs.conversation if self.svcs.conversation else None
+        conversation_process = None
+        if conversation is not None:
+            conversation_process = getattr(conversation, "process", None) or getattr(
+                conversation, "_process", None
+            )
+
+        self._shutdown_event.set()
+
+        with self._stop_lock:
+            if self._stop_completed:
+                return
+            self._stop_completed = True
+            self._running = False
+
+        if conversation and self.svcs.enable_conversation:
+            try:
+                conversation.stop()
+            except Exception:
+                pass
+
+            try:
+                conversation.join()
+            except Exception:
+                pass
+
+            if conversation_process is not None:
+                terminate = getattr(conversation_process, "terminate", None)
+                if callable(terminate):
+                    try:
+                        terminate()
+                    except Exception:
+                        pass
 
         if vision and self.svcs.enable_vision:
             try:
@@ -150,5 +189,45 @@ class AppRuntime:
                 except Exception:
                     pass
 
-        # Hook reserved for the WebSocket wrapper implementation that will
-        # arrive in the next iteration.
+        ws_thread = self._ws_thread
+        if ws_thread and ws_thread.is_alive():
+            ws_thread.join(timeout=1.0)
+        self._ws_thread = None
+
+    def _start_ws_server(self, vision: Any, *, host: str, port: int) -> None:
+        if self._ws_thread and self._ws_thread.is_alive():
+            return
+
+        def _run() -> None:
+            asyncio.run(self._run_ws_server(vision, host=host, port=port))
+
+        thread = threading.Thread(target=_run, name="ws-server", daemon=True)
+        self._ws_thread = thread
+        thread.start()
+
+    async def _run_ws_server(self, vision: Any, *, host: str, port: int) -> None:
+        handler = ws_server.make_handler(vision)
+        try:
+            import websockets
+        except Exception:  # pragma: no cover - library import failure
+            return
+
+        addr = ws_server._get_local_ip() if hasattr(ws_server, "_get_local_ip") else host
+        print(f"WebSocket listening at ws://{addr}:{port} ...")
+
+        async with websockets.serve(handler, host, port):
+            loop = asyncio.get_running_loop()
+            try:
+                await loop.run_in_executor(None, self._shutdown_event.wait)
+            finally:
+                await self._cancel_pending_tasks()
+
+    async def _cancel_pending_tasks(self) -> None:
+        loop = asyncio.get_running_loop()
+        pending = [task for task in asyncio.all_tasks(loop=loop) if not task.done()]
+        for task in pending:
+            if task is asyncio.current_task(loop=loop):
+                continue
+            task.cancel()
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)

--- a/Server/network/ws_server.py
+++ b/Server/network/ws_server.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 import asyncio, json, socket, time
 from typing import Callable, Optional
-import websockets
+
+try:  # pragma: no cover - optional dependency in tests
+    import websockets
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    websockets = None
+
 from app.services.vision_service import VisionService
 
 async def _wait_for_frame(svc: VisionService, timeout=3.0, poll=0.05) -> Optional[str]:
@@ -53,6 +58,8 @@ def make_handler(svc: VisionService) -> Callable:
     return handler
 
 async def start_ws_server_async(svc: VisionService, host: str = "0.0.0.0", port: int = 8765) -> None:
+    if websockets is None:  # pragma: no cover - guard for optional dependency
+        raise RuntimeError("websockets package is required to start the WS server")
     addr = _get_local_ip()
     print(f"WebSocket listening at ws://{addr}:{port} ...")
     async with websockets.serve(make_handler(svc), host, port):

--- a/Server/tests/test_app_runtime.py
+++ b/Server/tests/test_app_runtime.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import threading
+import sys
+import types
+from pathlib import Path
+
+cv2_stub = types.ModuleType("cv2")
+numpy_stub = types.ModuleType("numpy")
+
+
+def _no_op(*_args, **_kwargs) -> None:
+    return None
+
+
+cv2_stub.setNumThreads = _no_op  # type: ignore[attr-defined]
+sys.modules.setdefault("cv2", cv2_stub)
+sys.modules.setdefault("numpy", numpy_stub)
+
+numpy_stub.ndarray = type("ndarray", (), {})  # type: ignore[attr-defined]
+
+SERVER_ROOT = Path(__file__).resolve().parents[1]
+if str(SERVER_ROOT) not in sys.path:
+    sys.path.insert(0, str(SERVER_ROOT))
+
+vision_service_stub = types.ModuleType("app.services.vision_service")
+
+
+class _StubVisionService:  # pragma: no cover - minimal shim
+    pass
+
+
+vision_service_stub.VisionService = _StubVisionService
+sys.modules.setdefault("app.services.vision_service", vision_service_stub)
+
+from app.builder import AppServices
+from app.runtime import AppRuntime
+
+
+class _Recorder:
+    def __init__(self) -> None:
+        self.events: list[str] = []
+        self.lock = threading.Lock()
+
+    def add(self, name: str) -> None:
+        with self.lock:
+            self.events.append(name)
+
+    def index(self, name: str) -> int:
+        with self.lock:
+            return self.events.index(name)
+
+    def count(self, name: str) -> int:
+        with self.lock:
+            return self.events.count(name)
+
+
+class MockMovement:
+    def __init__(self, recorder: _Recorder) -> None:
+        self.recorder = recorder
+
+    def start(self) -> None:
+        self.recorder.add("movement.start")
+
+    def relax(self) -> None:
+        self.recorder.add("movement.relax")
+
+    def stop(self) -> None:
+        self.recorder.add("movement.stop")
+
+
+class MockVision:
+    def __init__(self, recorder: _Recorder) -> None:
+        self.recorder = recorder
+
+    def set_frame_callback(self, _cb) -> None:
+        self.recorder.add("vision.set_frame_callback")
+
+    def start(self, *, interval_sec: float, frame_handler=None) -> None:
+        self.recorder.add("vision.start")
+
+    def stop(self) -> None:
+        self.recorder.add("vision.stop")
+
+
+class MockProcess:
+    def __init__(self, recorder: _Recorder) -> None:
+        self.recorder = recorder
+
+    def terminate(self) -> None:
+        self.recorder.add("llm.terminate")
+
+
+class MockConversation:
+    def __init__(self, recorder: _Recorder) -> None:
+        self.recorder = recorder
+        self.started = threading.Event()
+        self.stopped = threading.Event()
+        self.process = MockProcess(recorder)
+
+    def start(self) -> None:
+        self.recorder.add("conversation.start")
+        self.started.set()
+
+    def stop(self) -> None:
+        self.recorder.add("conversation.stop")
+        self.stopped.set()
+
+    def join(self, timeout: float | None = None) -> bool:
+        self.recorder.add("conversation.join")
+        return True
+
+
+def _make_runtime(enable_ws: bool = False) -> tuple[AppRuntime, _Recorder, MockConversation]:
+    recorder = _Recorder()
+    services = AppServices()
+    services.enable_vision = True
+    services.enable_movement = True
+    services.enable_ws = enable_ws
+    services.enable_conversation = True
+    services.interval_sec = 0.1
+    services.vision = MockVision(recorder)
+    services.movement = MockMovement(recorder)
+    conversation = MockConversation(recorder)
+    services.conversation = conversation
+    runtime = AppRuntime(services)
+    return runtime, recorder, conversation
+
+
+def _run_runtime(runtime: AppRuntime) -> threading.Thread:
+    thread = threading.Thread(target=runtime.start, daemon=True)
+    thread.start()
+    return thread
+
+
+def test_runtime_starts_conversation_after_vision_and_movement() -> None:
+    runtime, recorder, conversation = _make_runtime()
+    thread = _run_runtime(runtime)
+
+    assert conversation.started.wait(timeout=1.0)
+
+    runtime.stop()
+    thread.join(timeout=1.0)
+
+    assert recorder.index("movement.start") < recorder.index("conversation.start")
+    assert recorder.index("vision.start") < recorder.index("conversation.start")
+
+
+def test_runtime_stop_is_idempotent_and_orders_shutdown() -> None:
+    runtime, recorder, conversation = _make_runtime()
+    thread = _run_runtime(runtime)
+
+    assert conversation.started.wait(timeout=1.0)
+
+    runtime.stop()
+    runtime.stop()
+    thread.join(timeout=1.0)
+
+    assert recorder.index("conversation.stop") < recorder.index("conversation.join")
+    assert recorder.index("conversation.join") < recorder.index("llm.terminate")
+    assert recorder.count("conversation.stop") == 1
+    assert recorder.count("llm.terminate") == 1
+    assert recorder.count("vision.stop") == 1
+    assert recorder.count("movement.stop") == 1


### PR DESCRIPTION
## Summary
- start the conversation service after booting vision and movement and manage the websocket listener with the runtime shutdown event
- ensure stop() only runs once, waits for the conversation thread, and terminates the llama process before relaxing hardware
- add a regression test covering start/stop ordering with mock services and make the websocket server tolerant to a missing websockets dependency during tests

## Testing
- pytest Server/tests/test_app_runtime.py

------
https://chatgpt.com/codex/tasks/task_e_68d3a401c7f0832ea2b44b8a9d2e022f