### PR TITLE
Improve conversation lifecycle logging and teardown

### DIFF
--- a/Server/app/logging_config.py
+++ b/Server/app/logging_config.py
@@ -9,7 +9,9 @@ LOG_FILE = os.path.join(os.path.dirname(__file__), "..", "..", "robot.log")
 def setup_logging() -> None:
     """Configure root logging with a rotating file handler."""
     logger = logging.getLogger()
-    logger.setLevel(logging.DEBUG)
+
+    root_level = os.getenv("ROOT_LOG_LEVEL", "DEBUG").upper()
+    logger.setLevel(getattr(logging, root_level, logging.DEBUG))
 
     # Avoid adding multiple handlers if setup_logging is called more than once
     if any(isinstance(h, RotatingFileHandler) for h in logger.handlers):
@@ -21,3 +23,10 @@ def setup_logging() -> None:
     )
     handler.setFormatter(formatter)
     logger.addHandler(handler)
+
+    conversation_level = os.getenv("CONVERSATION_LOG_LEVEL")
+    if conversation_level:
+        level_value = getattr(logging, conversation_level.upper(), None)
+        if isinstance(level_value, int):
+            conversation_logger = logging.getLogger("conversation")
+            conversation_logger.setLevel(level_value)


### PR DESCRIPTION
## Summary
- add structured lifecycle logging, context management, and atexit cleanup to the conversation service
- expose configurable log levels and improve readiness/cleanup telemetry for the conversation manager and llama-server process
- cover the new behavior with conversation service lifecycle tests and llama-server health-check log assertions

## Testing
- pytest Server/app/tests/test_conversation_service.py Server/tests/test_llama_server_process.py

------
https://chatgpt.com/codex/tasks/task_e_68d3a759fb0c832e99278a81f5e24986