### PR TITLE
Improve conversation service lifecycle

### DIFF
--- a/Server/app/runtime.py
+++ b/Server/app/runtime.py
@@ -141,11 +141,6 @@ class AppRuntime:
         vision = self.svcs.vision if self.svcs.vision else None
         movement = self.svcs.movement if self.svcs.movement else None
         conversation = self.svcs.conversation if self.svcs.conversation else None
-        conversation_process = None
-        if conversation is not None:
-            conversation_process = getattr(conversation, "process", None) or getattr(
-                conversation, "_process", None
-            )
 
         self._shutdown_event.set()
 
@@ -157,7 +152,7 @@ class AppRuntime:
 
         if conversation and self.svcs.enable_conversation:
             try:
-                conversation.stop()
+                conversation.stop(terminate_process=True, shutdown_resources=True)
             except Exception:
                 pass
 
@@ -165,14 +160,6 @@ class AppRuntime:
                 conversation.join()
             except Exception:
                 pass
-
-            if conversation_process is not None:
-                terminate = getattr(conversation_process, "terminate", None)
-                if callable(terminate):
-                    try:
-                        terminate()
-                    except Exception:
-                        pass
 
         if vision and self.svcs.enable_vision:
             try:

--- a/Server/core/VoiceInterface.py
+++ b/Server/core/VoiceInterface.py
@@ -220,6 +220,7 @@ class ConversationManager:
         llm_retry_max_delay: Optional[float] = None,
         stt_poll_interval: float = 0.02,
         speak_cooldown: float = SPEAK_COOLDOWN_SEC,
+        close_led_on_cleanup: bool = True,
     ) -> None:
         self.state = "NONE"
         self._stt = stt
@@ -236,6 +237,7 @@ class ConversationManager:
         self._stop_event = stop_event
         self._extra_stop_events = tuple(additional_stop_events or ())
         self._wait_until_ready = wait_until_ready
+        self._close_led_on_cleanup = close_led_on_cleanup
 
         self._llm_retry_max_attempts = max(1, llm_retry_max_attempts)
         self._llm_retry_initial_delay = max(0.0, llm_retry_initial_delay)
@@ -384,7 +386,7 @@ class ConversationManager:
             except Exception:  # pragma: no cover - defensive
                 pass
 
-        if hasattr(self._led, "close"):
+        if self._close_led_on_cleanup and hasattr(self._led, "close"):
             try:
                 self._led.close()
             except Exception as exc:  # pragma: no cover - defensive

--- a/Server/tests/test_app_runtime_conversation_integration.py
+++ b/Server/tests/test_app_runtime_conversation_integration.py
@@ -209,6 +209,19 @@ class StubLlamaProcess:
     def wait_ready(self, timeout: float) -> bool:
         return True
 
+    def poll_health(
+        self,
+        _base_url: str,
+        *,
+        endpoint: str = "/health",
+        method: str = "GET",
+        timeout: float = 5.0,
+        interval: float = 0.5,
+        max_retries: int = 3,
+        backoff: float = 2.0,
+    ) -> bool:
+        return True
+
 
 class StubLedHandler:
     def __init__(self) -> None:
@@ -265,6 +278,7 @@ def _build_runtime_with_conversation() -> tuple[
         llm_client: StubLLMClient,
         wait_until_ready,
         additional_stop_events=None,
+        close_led_on_cleanup: bool = False,
     ) -> _ConversationManager:
         stop_event = stop_event_ref.get("stop_event")
         if stop_event is None:
@@ -279,6 +293,7 @@ def _build_runtime_with_conversation() -> tuple[
             additional_stop_events=additional_stop_events,
             stt_poll_interval=0.01,
             speak_cooldown=0.05,
+            close_led_on_cleanup=close_led_on_cleanup,
         )
 
     conversation_service = ConversationService(
@@ -291,6 +306,10 @@ def _build_runtime_with_conversation() -> tuple[
         manager_kwargs={"wait_until_ready": lambda: None},
         readiness_timeout=0.1,
         shutdown_timeout=0.2,
+        health_check_interval=0.01,
+        health_check_max_retries=0,
+        health_check_timeout=0.1,
+        led_cleanup=led_handler.close,
     )
     stop_event_ref["stop_event"] = conversation_service.stop_event
 


### PR DESCRIPTION
## Summary
- add filesystem validation for llama assets and propagate conversation health-check settings in the builder
- extend ConversationService with HTTP health polling, reusable LED resources, and keep-alive stop semantics while updating AppRuntime shutdown
- expose a ConversationManager flag to skip LED teardown and adjust tests for the new lifecycle behavior

## Testing
- pytest Server/tests
- pytest *(fails: missing optional hardware/network dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d2afb4c928832e8ceecb5c313b0a3e