### PR TITLE
Run conversation service independently of FSM

### DIFF
--- a/Server/app/builder.py
+++ b/Server/app/builder.py
@@ -328,16 +328,9 @@ def build(config_path: str = CONFIG_PATH) -> AppServices:
         register_stop_event(conversation_service.stop_event)
         services.conversation = conversation_service
 
-        def _on_interact(_fsm: Any) -> None:
-            conversation_service.start()
-
-        def _on_exit_interact(_fsm: Any) -> None:
-            conversation_service.stop()
-
-        fsm_callbacks = {
-            "on_interact": _on_interact,
-            "on_exit_interact": _on_exit_interact,
-        }
+        # The conversation service now runs independently of the FSM lifecycle.
+        # It is started and stopped directly by the AppRuntime alongside the
+        # rest of the services, so no FSM callbacks are required here.
 
     if services.vision and services.movement:
         from .controllers.social_fsm import SocialFSM


### PR DESCRIPTION
## Summary
- remove SocialFSM conversation callbacks so the ConversationService lifecycle is managed solely by AppRuntime

## Testing
- pytest Server/tests/test_app_runtime_conversation_integration.py

------
https://chatgpt.com/codex/tasks/task_e_68d40bee9aa4832e956ff0ed992bd798