### PR TITLE
Handle LLM errors and verify LLM availability

### DIFF
--- a/Server/app/services/conversation_service.py
+++ b/Server/app/services/conversation_service.py
@@ -157,6 +157,20 @@ class ConversationService:
                 self._process.terminate()
                 return
 
+            query_callable = getattr(self._llm_client, "query", None)
+            if callable(query_callable):
+                try:
+                    self._logger.info("Performing non-blocking LLM smoke ping")
+                    query_callable(
+                        [
+                            {"role": "system", "content": "ping check"},
+                            {"role": "user", "content": "ping"},
+                        ],
+                        max_reply_chars=8,
+                    )
+                except Exception as exc:  # pragma: no cover - network dependent
+                    self._logger.warning("LLM smoke check failed: %s", exc)
+
             manager_kwargs: Dict[str, Any] = {
                 "stt": self._stt,
                 "tts": self._tts,

--- a/Server/core/VoiceInterface.py
+++ b/Server/core/VoiceInterface.py
@@ -35,6 +35,7 @@ LED_STATE_MAP = {
     "ATTENTIVE_LISTEN": "listen",
     "THINK": "processing",
     "SPEAK": "speaking",
+    "ERROR": "error",
 }
 
 
@@ -157,6 +158,9 @@ class LedStateHandler:
         elif state == "speaking":
             await self._controller.stop_animation()
             await self._controller.set_all([0, 0, 255])
+        elif state == "error":
+            await self._controller.stop_animation()
+            await self._controller.set_all([255, 0, 0])
         else:
             await self._controller.stop_animation()
             await self._controller.set_all([0, 0, 0])
@@ -436,6 +440,7 @@ class ConversationManager:
                         raise
                     except Exception as exc:
                         logger.error("LLM processing failed: %s", exc)
+                        self.set_state("ERROR")
                         self._stt.resume()
                         self.set_state("WAKE")
 


### PR DESCRIPTION
## Summary
- map the new ERROR LED state to a red solid color and surface it when the LLM call fails
- keep the conversation manager reset to WAKE after resuming STT from an error
- perform an optional smoke ping against the LLM client after the server health check

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d4110ed0f4832e900cffa3aaee7612