### PR TITLE
Remove close_led_on_cleanup defaulting

### DIFF
--- a/Server/app/services/conversation_service.py
+++ b/Server/app/services/conversation_service.py
@@ -302,7 +302,6 @@ class ConversationService:
                 "llm_client": self._llm_client,
             }
             manager_kwargs.update(self._extra_manager_kwargs)
-            manager_kwargs.setdefault("close_led_on_cleanup", False)
 
             process_info = {
                 "llama_binary": str(getattr(self._process, "binary_path", "")),


### PR DESCRIPTION
## Summary
- stop setting the `close_led_on_cleanup` default in the conversation service manager kwargs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d42264c790832e857dce4222c278f4