### PR TITLE
Refactor conversation helpers into dedicated module

### DIFF
--- a/Server/app/builder/__init__.py
+++ b/Server/app/builder/__init__.py
@@ -6,6 +6,7 @@ import sys
 from types import ModuleType
 from typing import Any
 
+from . import conversation_builder as _conversation_builder
 from . import core_builder as _core_builder
 
 
@@ -23,12 +24,12 @@ _module.__dict__.update(
     CONFIG_PATH=_core_builder.CONFIG_PATH,
     AppServices=_core_builder.AppServices,
     build=_core_builder.build,
-    _build_conversation_llm_client=_core_builder._build_conversation_llm_client,
-    _build_conversation_process=_core_builder._build_conversation_process,
-    _build_conversation_stt_service=_core_builder._build_conversation_stt_service,
-    _build_conversation_tts=_core_builder._build_conversation_tts,
-    _build_conversation_led_handler=_core_builder._build_conversation_led_handler,
-    _build_conversation_manager_factory=_core_builder._build_conversation_manager_factory,
+    _build_conversation_llm_client=_conversation_builder._build_conversation_llm_client,
+    _build_conversation_process=_conversation_builder._build_conversation_process,
+    _build_conversation_stt_service=_conversation_builder._build_conversation_stt_service,
+    _build_conversation_tts=_conversation_builder._build_conversation_tts,
+    _build_conversation_led_handler=_conversation_builder._build_conversation_led_handler,
+    _build_conversation_manager_factory=_conversation_builder._build_conversation_manager_factory,
 )
 
 __all__ = [

--- a/Server/app/builder/conversation_builder.py
+++ b/Server/app/builder/conversation_builder.py
@@ -1,0 +1,121 @@
+"""Helpers for building conversation-related services."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from typing import Any, Callable, Dict, Optional, Tuple
+
+
+__all__ = [
+    "_build_conversation_llm_client",
+    "_build_conversation_process",
+    "_build_conversation_stt_service",
+    "_build_conversation_tts",
+    "_build_conversation_led_handler",
+    "_build_conversation_manager_factory",
+]
+
+
+def _build_conversation_llm_client(cfg: Dict[str, Any]) -> Any:
+    from core.llm.llm_client import LlamaClient
+
+    return LlamaClient(
+        base_url=cfg.get("llm_base_url") or None,
+        request_timeout=cfg.get("llm_request_timeout"),
+    )
+
+
+def _build_conversation_process(cfg: Dict[str, Any]) -> Any:
+    from core.llm.llama_server_process import LlamaServerProcess
+
+    threads = cfg.get("threads") or None
+    parallel = cfg.get("max_parallel_inference") or None
+
+    return LlamaServerProcess(
+        cfg["llama_binary"],
+        cfg["model_path"],
+        port=int(cfg.get("port", 0)),
+        threads=threads,
+        parallel=parallel,
+    )
+
+
+def _build_conversation_stt_service(_cfg: Dict[str, Any]) -> Any:
+    from core.VoiceInterface import STTService
+    from core.hearing.stt import SpeechToText
+
+    stt_engine = SpeechToText()
+    return STTService(stt_engine)
+
+
+def _build_conversation_tts(_cfg: Dict[str, Any]) -> Any:
+    from core.voice.tts import TextToSpeech
+
+    return TextToSpeech()
+
+
+def _build_conversation_led_handler(
+    _cfg: Dict[str, Any]
+) -> Tuple[Any, Callable[[], None]]:
+    from LedController import LedController
+    from core.VoiceInterface import LedStateHandler
+
+    loop = asyncio.new_event_loop()
+    loop_thread = threading.Thread(target=loop.run_forever, daemon=True)
+    loop_thread.start()
+    controller = LedController(loop=loop)
+    handler = LedStateHandler(controller, loop, loop_thread=loop_thread)
+
+    def _cleanup() -> None:
+        try:
+            handler.close()
+        finally:
+            try:
+                loop.call_soon_threadsafe(loop.stop)
+            except RuntimeError:
+                pass
+            if loop_thread.is_alive():
+                loop_thread.join(timeout=1)
+
+    return handler, _cleanup
+
+
+def _build_conversation_manager_factory() -> Tuple[
+    Callable[..., Any],
+    Dict[str, Any],
+    Callable[[threading.Event], None],
+]:
+    from core.VoiceInterface import ConversationManager
+
+    stop_event_ref: Dict[str, threading.Event] = {}
+
+    def _register(event: threading.Event) -> None:
+        stop_event_ref["stop_event"] = event
+
+    def _factory(
+        *,
+        stt: Any,
+        tts: Any,
+        led_controller: Any,
+        llm_client: Any,
+        wait_until_ready: Callable[[], None],
+        additional_stop_events: Optional[Tuple[threading.Event, ...]] = None,
+        **kwargs,
+    ) -> Any:
+        stop_event = stop_event_ref.get("stop_event")
+        if stop_event is None:
+            raise RuntimeError("Conversation stop event not registered")
+        return ConversationManager(
+            stt=stt,
+            tts=tts,
+            led_controller=led_controller,
+            llm_client=llm_client,
+            stop_event=stop_event,
+            wait_until_ready=wait_until_ready,
+            additional_stop_events=additional_stop_events,
+            **kwargs,
+        )
+
+    manager_kwargs: Dict[str, Any] = {"wait_until_ready": lambda: None}
+    return _factory, manager_kwargs, _register

--- a/Server/app/builder/core_builder.py
+++ b/Server/app/builder/core_builder.py
@@ -3,11 +3,18 @@ from __future__ import annotations
 import json
 import logging
 
-import asyncio
-import threading
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable, Dict, Optional, Tuple
+from typing import Any, Callable, Dict, Optional
+
+from .conversation_builder import (
+    _build_conversation_led_handler,
+    _build_conversation_llm_client,
+    _build_conversation_manager_factory,
+    _build_conversation_process,
+    _build_conversation_stt_service,
+    _build_conversation_tts,
+)
 
 
 CONFIG_PATH = str(Path(__file__).resolve().parents[1] / "config" / "app.json")
@@ -43,112 +50,6 @@ class AppServices:
 def _load_json(path: str) -> Dict[str, Any]:
     with open(path, "r", encoding="utf-8") as file:
         return json.load(file)
-
-
-def _build_conversation_llm_client(cfg: Dict[str, Any]) -> Any:
-    from core.llm.llm_client import LlamaClient
-
-    return LlamaClient(
-        base_url=cfg.get("llm_base_url") or None,
-        request_timeout=cfg.get("llm_request_timeout"),
-    )
-
-
-def _build_conversation_process(cfg: Dict[str, Any]) -> Any:
-    from core.llm.llama_server_process import LlamaServerProcess
-
-    threads = cfg.get("threads") or None
-    parallel = cfg.get("max_parallel_inference") or None
-
-    return LlamaServerProcess(
-        cfg["llama_binary"],
-        cfg["model_path"],
-        port=int(cfg.get("port", 0)),
-        threads=threads,
-        parallel=parallel,
-    )
-
-
-def _build_conversation_stt_service(_cfg: Dict[str, Any]) -> Any:
-    from core.VoiceInterface import STTService
-    from core.hearing.stt import SpeechToText
-
-    stt_engine = SpeechToText()
-    return STTService(stt_engine)
-
-
-def _build_conversation_tts(_cfg: Dict[str, Any]) -> Any:
-    from core.voice.tts import TextToSpeech
-
-    return TextToSpeech()
-
-
-def _build_conversation_led_handler(
-    _cfg: Dict[str, Any]
-) -> Tuple[Any, Callable[[], None]]:
-    from LedController import LedController
-    from core.VoiceInterface import LedStateHandler
-
-    loop = asyncio.new_event_loop()
-    loop_thread = threading.Thread(target=loop.run_forever, daemon=True)
-    loop_thread.start()
-    controller = LedController(loop=loop)
-    handler = LedStateHandler(controller, loop, loop_thread=loop_thread)
-
-    def _cleanup() -> None:
-        try:
-            handler.close()
-        finally:
-            try:
-                loop.call_soon_threadsafe(loop.stop)
-            except RuntimeError:
-                pass
-            if loop_thread.is_alive():
-                loop_thread.join(timeout=1)
-
-    return handler, _cleanup
-
-
-def _build_conversation_manager_factory() -> Tuple[
-    Callable[..., Any],
-    Dict[str, Any],
-    Callable[[threading.Event], None],
-]:
-    from core.VoiceInterface import ConversationManager
-
-    stop_event_ref: Dict[str, threading.Event] = {}
-
-    def _register(event: threading.Event) -> None:
-        stop_event_ref["stop_event"] = event
-
-    def _factory(
-    *,
-    stt: Any,
-    tts: Any,
-    led_controller: Any,
-    llm_client: Any,
-    wait_until_ready: Callable[[], None],
-    additional_stop_events: Optional[Tuple[threading.Event, ...]] = None,
-    **kwargs,
-    ) -> Any:
-        stop_event = stop_event_ref.get("stop_event")
-        if stop_event is None:
-            raise RuntimeError("Conversation stop event not registered")
-        return ConversationManager(
-            stt=stt,
-            tts=tts,
-            led_controller=led_controller,
-            llm_client=llm_client,
-            stop_event=stop_event,
-            wait_until_ready=wait_until_ready,
-            additional_stop_events=additional_stop_events,
-            **kwargs,
-        )
-
-    manager_kwargs: Dict[str, Any] = {"wait_until_ready": lambda: None}
-    return _factory, manager_kwargs, _register
-
-
 def build(config_path: str = CONFIG_PATH) -> AppServices:
     """Build :class:`AppServices` instances from a configuration file."""
 


### PR DESCRIPTION
## Summary
- move the conversation helper functions into a new `conversation_builder` module
- re-export the helpers from `app.builder` to maintain the existing public API
- update `core_builder` to consume the helpers from the new module

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e2918ab018832eb7e3d790e9a1d2e7