### PR TITLE
Add boot and fatal LED indicators for runtime startup

### DIFF
--- a/Server/app/runtime.py
+++ b/Server/app/runtime.py
@@ -99,6 +99,13 @@ class AppRuntime:
         movement = self.svcs.movement if self.svcs.movement else None
         conversation = self.svcs.conversation if self.svcs.conversation else None
 
+        led = None
+        if conversation and hasattr(conversation, "_led_controller"):
+            led = conversation._led_controller
+
+        if led:
+            led.set_state("boot")
+
         if movement and self.svcs.enable_movement:
             movement.start()
             movement.relax()
@@ -124,10 +131,14 @@ class AppRuntime:
                     logger.info("AppRuntime: starting conversation service")
                     conversation.start()
                     logger.info("AppRuntime: conversation service started")
+                    if led:
+                        led.set_state("ready")
                 except Exception:
                     logger.exception(
                         "AppRuntime: error while starting conversation service"
                     )
+                    if led:
+                        led.set_state("fatal")
                     raise
 
             if self.svcs.enable_ws and vision:

--- a/Server/core/VoiceInterface.py
+++ b/Server/core/VoiceInterface.py
@@ -145,7 +145,13 @@ class LedStateHandler:
             logger.debug("LED loop no longer running")
 
     async def _apply_state(self, state: str) -> None:
-        if state == "wake":
+        if state == "boot":
+            await self._controller.stop_animation()
+            await self._controller.set_all([64, 64, 64])
+        elif state == "fatal":
+            await self._controller.stop_animation()
+            await self._controller.set_all([255, 0, 0])
+        elif state == "wake":
             await self._controller.stop_animation()
             await self._controller.set_all([0, 128, 0])
         elif state == "listen":


### PR DESCRIPTION
## Summary
- add boot and fatal LED color mappings to the voice interface LED handler
- drive runtime startup LEDs for boot, ready, and fatal error transitions when initializing services

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3e419fc84832ea2dde6c54e9f374a