### PR TITLE
Add pause handling to SocialFSM

### DIFF
--- a/Server/app/controllers/face_tracker.py
+++ b/Server/app/controllers/face_tracker.py
@@ -151,3 +151,20 @@ class FaceTracker:
         """Update head position based on vision ``result`` and timestep ``dt``."""
 
         self.tracker.update(result, dt)
+
+    # ----- State helpers -------------------------------------------------------
+    @property
+    def locked(self) -> bool:
+        return getattr(self.tracker, "locked", False)
+
+    @property
+    def had_target(self) -> bool:
+        return getattr(self.tracker, "had_target", False)
+
+    @property
+    def lost_target(self) -> bool:
+        return getattr(self.tracker, "lost_target", False)
+
+    @property
+    def horizontal_error(self) -> float:
+        return getattr(self.tracker, "horizontal_error", 0.0)


### PR DESCRIPTION
## Summary
- add pause/resume controls to SocialFSM so callers can temporarily suspend reactions
- expose tracker state, including the last horizontal error, through the face tracker to avoid duplicate math

## Testing
- pytest Server/tests/test_social_fsm.py

------
https://chatgpt.com/codex/tasks/task_e_68e4b0c48240832e8657cc07252e6621