### PR TITLE
Add social mute control for social FSM

### DIFF
--- a/Server/app/controllers/behavior_manager.py
+++ b/Server/app/controllers/behavior_manager.py
@@ -57,14 +57,24 @@ class BehaviorManager:
         if state in {"THINK", "SPEAK"}:
             self._set_mode("CONVERSE")
             self._set_face_tracking(False)
+            if hasattr(self.social_fsm, "pause"):
+                self.social_fsm.pause()
             self._stop_motion()
         elif state in {"ATTENTIVE_LISTEN", "WAKE"}:
             self._set_mode("SOCIAL")
             self._set_face_tracking(True)
+            if hasattr(self.social_fsm, "resume"):
+                self.social_fsm.resume()
+            if hasattr(self.social_fsm, "mute_social"):
+                self.social_fsm.mute_social(True)
             self._movement_relaxed = False
         else:
             self._set_mode("IDLE")
-            self._set_face_tracking(False)
+            self._set_face_tracking(True)
+            if hasattr(self.social_fsm, "resume"):
+                self.social_fsm.resume()
+            if hasattr(self.social_fsm, "mute_social"):
+                self.social_fsm.mute_social(False)
             self._relax_movement()
 
     def _get_conversation_state(self) -> Optional[str]:

--- a/Server/app/controllers/social_fsm.py
+++ b/Server/app/controllers/social_fsm.py
@@ -56,6 +56,7 @@ class SocialFSM:
         self.audio = None
         self._drift_until = None
         self.paused = False
+        self.social_muted = False
         callbacks = dict(callbacks or {})
         disable_default = bool(callbacks.pop("disable_default_interact", False))
         self._callbacks: Dict[str, Callable[["SocialFSM"], None]] = {}
@@ -95,6 +96,15 @@ class SocialFSM:
 
         self.paused = False
         self.logger.info("SocialFSM resumed")
+
+    def mute_social(self, enabled: bool) -> None:
+        """Enable or disable only the social reactions (e.g. meows) while keeping tracking active."""
+
+        self.social_muted = enabled
+        if enabled:
+            self.logger.info("SocialFSM: social reactions muted")
+        else:
+            self.logger.info("SocialFSM: social reactions unmuted")
 
     def on_frame(self, result: Dict | None, dt: float) -> None:
         if self.paused:
@@ -157,6 +167,8 @@ class SocialFSM:
     def _on_interact(self) -> None:
         now = time.monotonic()
         self.last_active = now
+        if self.social_muted:
+            return
         if now < self._next_meow_time:
             return
         sound_file = Path(__file__).resolve().parents[2] / "sounds" / "meow.wav"


### PR DESCRIPTION
## Summary
- add a social_muted flag and mute_social method to SocialFSM
- prevent interaction sounds while muted
- extend BehaviorManager coordination to pause, resume, and mute social reactions based on conversation state

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e4b449d3e0832e8e053a7d38f077df