### PR TITLE
Add cognitive conversation service to sandbox runtime

### DIFF
--- a/sandbox/sandbox_runtime.py
+++ b/sandbox/sandbox_runtime.py
@@ -1,13 +1,16 @@
 """Entry point for running the Lumo runtime in sandbox mode."""
 from __future__ import annotations
 
+import json
 import logging
 import sys
 import threading
 import time
 import types
+import urllib.error
+import urllib.request
 from pathlib import Path
-from typing import Optional
+from typing import Callable, Dict, Iterable, Optional, Tuple
 
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
@@ -234,62 +237,498 @@ class MockSocialFSM:
         self.state = new_state
 
 
-class SandboxConversationService:
-    """Small conversation loop that echoes user input through the voice mock."""
+class MockLLMClient:
+    """Lightweight canned-response client used when no LLM is reachable."""
+
+    def __init__(self, *, message: str = "Lumo is not thinking...") -> None:
+        self._message = message
+        self.base_url = "mock://llm"
+        self._logger = logging.getLogger("sandbox.cognitive.mock_llm")
+
+    def query(self, _messages, *, max_reply_chars: int = 220) -> str:
+        self._logger.debug("MockLLMClient responding with canned message")
+        return self._message[:max_reply_chars]
+
+
+class _SimpleHttpLLMClient:
+    """Minimal HTTP client compatible with the llama.cpp REST API."""
+
+    def __init__(self, base_url: str, *, timeout: float = 10.0) -> None:
+        self.base_url = base_url.rstrip("/")
+        self._timeout = timeout
+        self._logger = logging.getLogger("sandbox.cognitive.http_llm")
+
+    @property
+    def chat_url(self) -> str:
+        return f"{self.base_url}/v1/chat/completions"
+
+    def query(self, messages, *, max_reply_chars: int = 220) -> str:
+        payload = json.dumps({"model": "sandbox", "messages": list(messages)})
+        request = urllib.request.Request(
+            self.chat_url,
+            data=payload.encode("utf-8"),
+            method="POST",
+            headers={"Content-Type": "application/json"},
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=self._timeout) as response:
+                data = json.loads(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as exc:  # pragma: no cover - network dependent
+            self._logger.warning("HTTP error querying LLM: %s", exc)
+            raise
+        except urllib.error.URLError as exc:  # pragma: no cover - network dependent
+            self._logger.warning("URL error querying LLM: %s", exc)
+            raise
+
+        choice = data.get("choices") or []
+        if choice:
+            message = choice[0].get("message") or {}
+            content = str(message.get("content", "")).strip()
+        else:
+            content = str(data)
+
+        if max_reply_chars > 0:
+            content = content[:max_reply_chars]
+        return content or "(no response)"
+
+
+class _SandboxLlamaProcess:
+    """Stub ``LlamaServerProcess`` compatible with :class:`ConversationService`."""
+
+    def __init__(self, *, available: bool, base_url: Optional[str]) -> None:
+        self.port = 0
+        self._available = available
+        self._base_url = (base_url or "").rstrip("/")
+        self.logger = logging.getLogger("sandbox.cognitive.llama_process")
+
+    def is_running(self) -> bool:
+        return True
+
+    def start(self) -> None:
+        self.logger.debug("Sandbox llama process start() invoked")
+
+    def wait_ready(self, timeout: Optional[float] = None) -> bool:
+        self.logger.debug(
+            "Sandbox llama process wait_ready(timeout=%s) -> True", timeout
+        )
+        return True
+
+    def poll(self) -> Optional[int]:
+        return None
+
+    def poll_health(
+        self,
+        base_url: str,
+        *,
+        interval: float,
+        max_retries: int,
+        backoff: float,
+        timeout: Optional[float],
+    ) -> bool:
+        if not self._available:
+            self.logger.debug("Skipping health poll: LLM not available")
+            return True
+
+        url = f"{(base_url or self._base_url).rstrip('/')}/health"
+        retries = max(0, int(max_retries)) + 1
+        attempt = 0
+        last_error: Optional[Exception] = None
+        while attempt < retries:
+            attempt += 1
+            try:
+                with urllib.request.urlopen(url, timeout=timeout or interval) as resp:
+                    if 200 <= resp.status < 500:
+                        self.logger.debug(
+                            "Health check succeeded on attempt %s with status %s",
+                            attempt,
+                            resp.status,
+                        )
+                        return True
+            except urllib.error.HTTPError as exc:  # pragma: no cover - network dependent
+                self.logger.info("Health endpoint returned HTTP %s", exc.code)
+                return True
+            except urllib.error.URLError as exc:  # pragma: no cover - network dependent
+                last_error = exc
+                self.logger.debug("Health poll attempt %s failed: %s", attempt, exc)
+            time.sleep(min(interval * (backoff ** attempt), 1.0))
+
+        if last_error:
+            self.logger.warning("Health checks failed: %s", last_error)
+        return False
+
+    def terminate(self) -> None:
+        self.logger.debug("Sandbox llama process terminate() invoked")
+
+
+class _SandboxConversationManager:
+    """Conversation manager used by the sandbox cognitive service."""
+
+    def __init__(
+        self,
+        *,
+        stt: MockVoiceService,
+        tts: MockVoiceService,
+        led_controller: MockLedController,
+        llm_client,
+        stop_event: threading.Event,
+        wait_until_ready: Callable[[], None],
+        additional_stop_events: Optional[Iterable[threading.Event]] = None,
+        logger: Optional[logging.Logger] = None,
+    ) -> None:
+        self._stt = stt
+        self._tts = tts
+        self._led = led_controller
+        self._llm = llm_client
+        self._stop_event = stop_event
+        self._extra_stops = tuple(additional_stop_events or ())
+        self._wait_until_ready = wait_until_ready
+        self._logger = logger or logging.getLogger("sandbox.cognitive.manager")
+        self._paused = False
+        self._running = False
+
+    def run(self, stop_event: Optional[threading.Event] = None) -> None:
+        stop = stop_event or self._stop_event
+        self._logger.info("Sandbox conversation manager started")
+        self._wait_until_ready()
+        self._stt.start()
+        self._running = True
+        try:
+            while not stop.is_set() and not self._stop_event.is_set():
+                if any(ev.is_set() for ev in self._extra_stops):
+                    self._logger.debug("Additional stop event triggered")
+                    break
+
+                if self._paused:
+                    time.sleep(0.05)
+                    continue
+
+                utterance = self._stt.listen()
+                if utterance is None:
+                    continue
+                utterance = utterance.strip()
+                if not utterance:
+                    continue
+
+                self._led.set_color("thinking")
+                self._logger.debug("User said: %s", utterance)
+
+                messages = [
+                    {
+                        "role": "system",
+                        "content": "You are Lumo, a friendly companion robot.",
+                    },
+                    {"role": "user", "content": utterance},
+                ]
+
+                try:
+                    reply = self._llm.query(messages, max_reply_chars=220)
+                except Exception as exc:  # pragma: no cover - network dependent
+                    self._logger.warning("LLM query failed: %s", exc)
+                    reply = "I am having trouble thinking right now."
+
+                self._led.set_color("speaking")
+                self._tts.speak(reply)
+                self._led.set_color("idle")
+        finally:
+            self._running = False
+            self._led.set_color("idle")
+            self._logger.info("Sandbox conversation manager stopped")
+
+    def pause_stt(self) -> None:
+        self._logger.debug("pause_stt called")
+        self._paused = True
+
+    def drain_queues(self) -> None:
+        self._logger.debug("drain_queues called (no-op)")
+
+    def request_stop(self) -> None:
+        self._logger.debug("request_stop called")
+        self._stop_event.set()
+
+    def stop(self) -> None:
+        self._logger.debug("stop called")
+        self._paused = True
+        self._running = False
+
+
+def _build_sandbox_manager_factory() -> Tuple[
+    Callable[..., _SandboxConversationManager],
+    Dict[str, object],
+    Callable[[threading.Event], None],
+]:
+    stop_ref: Dict[str, threading.Event] = {}
+
+    def register(event: threading.Event) -> None:
+        stop_ref["stop_event"] = event
+
+    def factory(
+        *,
+        stt: MockVoiceService,
+        tts: MockVoiceService,
+        led_controller: MockLedController,
+        llm_client,
+        wait_until_ready: Callable[[], None],
+        additional_stop_events: Optional[Iterable[threading.Event]] = None,
+        logger: Optional[logging.Logger] = None,
+        **_kwargs,
+    ) -> _SandboxConversationManager:
+        stop_event = stop_ref.get("stop_event")
+        if stop_event is None:
+            raise RuntimeError("Sandbox manager stop_event not registered")
+        return _SandboxConversationManager(
+            stt=stt,
+            tts=tts,
+            led_controller=led_controller,
+            llm_client=llm_client,
+            stop_event=stop_event,
+            wait_until_ready=wait_until_ready,
+            additional_stop_events=additional_stop_events,
+            logger=logger,
+        )
+
+    manager_kwargs: Dict[str, object] = {
+        "wait_until_ready": lambda: None,
+        "logger": logging.getLogger("sandbox.cognitive.manager"),
+    }
+    return factory, manager_kwargs, register
+
+
+def _load_sandbox_config(config_path: Path) -> Dict[str, object]:
+    try:
+        with config_path.open("r", encoding="utf-8") as fh:
+            return json.load(fh)
+    except FileNotFoundError:
+        logging.getLogger("sandbox.cognitive").warning(
+            "sandbox_config.json not found at %s", config_path
+        )
+    except json.JSONDecodeError as exc:
+        logging.getLogger("sandbox.cognitive").warning(
+            "Invalid sandbox_config.json (%s): %s", config_path, exc
+        )
+    return {}
+
+
+class CognitiveConversationService:
+    """Conversation service that optionally delegates to the real runtime."""
 
     def __init__(self, voice: MockVoiceService, led: MockLedController) -> None:
-        self.logger = logging.getLogger("mock.conversation")
+        self.logger = logging.getLogger("sandbox.cognitive.conversation")
         self.voice = voice
         self._led_controller = led
         self.state = "IDLE"
-        self._running = False
         self._thread: Optional[threading.Thread] = None
+        self._running = False
+        self._conversation = None
+        self._stop_fallback = threading.Event()
 
-    def start(self) -> None:
-        if self._running:
+        config_path = Path(__file__).with_name("sandbox_config.json")
+        self._config = _load_sandbox_config(config_path)
+        self._llm_base_url = str(
+            self._config.get("llm_server")
+            or self._config.get("llm_base_url")
+            or ""
+        ).strip()
+
+    # ------------------------------------------------------------------ helpers
+    def _resolve_conversation_class(self):
+        try:
+            from app.services.conversation_service import ConversationService
+
+            return ConversationService
+        except Exception as exc:  # pragma: no cover - import defensive
+            self.logger.warning(
+                "Unable to import ConversationService: %s", exc
+            )
+            return None
+
+    def _ping_llm(self, base_url: str, *, timeout: float = 1.5) -> bool:
+        if not base_url:
+            return False
+        url_candidates = [
+            f"{base_url.rstrip('/')}/health",
+            base_url.rstrip("/") or base_url,
+        ]
+        for url in url_candidates:
+            try:
+                with urllib.request.urlopen(url, timeout=timeout) as resp:
+                    if 200 <= resp.status < 500:
+                        return True
+            except urllib.error.HTTPError as exc:  # pragma: no cover - network dependent
+                if 400 <= exc.code < 500:
+                    return True
+            except urllib.error.URLError:
+                continue
+        return False
+
+    def _build_llm_client(self, base_url: str, available: bool):
+        if not available:
+            return MockLLMClient()
+
+        try:
+            from core.llm.llm_client import LlamaClient
+
+            client = LlamaClient(base_url=base_url)
+            self.logger.info("Using real LlamaClient for LLM interactions")
+            return client
+        except Exception as exc:  # pragma: no cover - import defensive
+            self.logger.warning(
+                "Falling back to simple HTTP client due to import error: %s", exc
+            )
+            return _SimpleHttpLLMClient(base_url)
+
+    def _create_conversation(self, llm_client, available: bool):
+        conversation_cls = self._resolve_conversation_class()
+        if conversation_cls is None:
+            return None
+
+        process = _SandboxLlamaProcess(available=available, base_url=self._llm_base_url)
+        manager_factory, manager_kwargs, register = _build_sandbox_manager_factory()
+
+        conversation = conversation_cls(
+            stt=self.voice,
+            tts=self.voice,
+            led_controller=self._led_controller,
+            llm_client=llm_client,
+            process=process,
+            manager_factory=manager_factory,
+            manager_kwargs=manager_kwargs,
+            readiness_timeout=1.0,
+            health_check_base_url=self._llm_base_url if available else None,
+            health_check_interval=0.5,
+            health_check_max_retries=1,
+            health_check_backoff=1.2,
+            health_check_timeout=1.0,
+            led_cleanup=None,
+            logger=logging.getLogger("sandbox.cognitive.real_service"),
+        )
+
+        register(conversation.stop_event)
+        return conversation
+
+    def _start_fallback_loop(self, llm_client) -> None:
+        if self._thread and self._thread.is_alive():
             return
-        self._running = True
-        self.voice.start()
-        thread = threading.Thread(target=self._loop, name="mock-conversation", daemon=True)
+        self._stop_fallback.clear()
+        thread = threading.Thread(
+            target=self._loop,
+            name="sandbox-conversation",
+            daemon=True,
+            args=(llm_client,),
+        )
         self._thread = thread
         thread.start()
-        self.logger.info("Mock conversation service started")
 
-    def _loop(self) -> None:
-        while self._running:
+    def _loop(self, llm_client) -> None:
+        while not self._stop_fallback.is_set():
             utterance = self.voice.listen()
             if utterance is None:
                 continue
+            utterance = utterance.strip()
             if not utterance:
                 continue
+
             self.state = "THINK"
             self._led_controller.set_color("thinking")
-            self.logger.debug("Processing utterance: %s", utterance)
-            time.sleep(0.2)
-            response = f"I heard: {utterance}"
+            messages = [
+                {
+                    "role": "system",
+                    "content": "You are Lumo, a friendly companion robot.",
+                },
+                {"role": "user", "content": utterance},
+            ]
+            try:
+                reply = llm_client.query(messages, max_reply_chars=220)
+            except Exception as exc:  # pragma: no cover - network dependent
+                self.logger.warning("Fallback LLM query failed: %s", exc)
+                reply = "I am having trouble thinking right now."
+
             self.state = "SPEAK"
             self._led_controller.set_color("speaking")
-            self.voice.speak(response)
+            self.voice.speak(reply)
             self.state = "IDLE"
             self._led_controller.set_color("idle")
+
+    # ------------------------------------------------------------------ API
+    def start(self) -> None:
+        if self._running:
+            return
+
+        self.voice.start()
+
+        base_url = self._llm_base_url
+        available = self._ping_llm(base_url) if base_url else False
+        if available:
+            self.logger.info("Connected to LLM server at %s", base_url)
+        else:
+            if base_url:
+                self.logger.warning(
+                    "LLM server %s not reachable, using mock responses", base_url
+                )
+            else:
+                self.logger.info("No LLM server configured, using mock responses")
+
+        llm_client = self._build_llm_client(base_url or "http://127.0.0.1:8080", available)
+
+        conversation = self._create_conversation(llm_client, available)
+        if conversation is not None:
+            try:
+                conversation.start()
+                self._conversation = conversation
+                self._running = True
+                self.logger.info(
+                    "Cognitive conversation service started using %s LLM",
+                    "real" if available else "mock",
+                )
+                return
+            except Exception as exc:  # pragma: no cover - defensive
+                self.logger.exception(
+                    "Failed to start ConversationService, falling back to sandbox loop: %s",
+                    exc,
+                )
+                self._conversation = None
+
+        self.logger.info("Starting fallback sandbox conversation loop")
+        self._running = True
+        self._start_fallback_loop(llm_client)
 
     def stop(self, terminate_process: bool = False, shutdown_resources: bool = False) -> None:
         if not self._running:
             return
-        self.logger.info("Mock conversation service stopping")
-        self._running = False
-        self.voice.stop()
 
-    def join(self, timeout: Optional[float] = None) -> None:
-        thread = self._thread
-        if thread and thread.is_alive():
-            thread.join(timeout=timeout)
+        if self._conversation is not None:
+            self.logger.info("Stopping ConversationService")
+            try:
+                self._conversation.stop(
+                    terminate_process=terminate_process,
+                    shutdown_resources=shutdown_resources,
+                )
+            finally:
+                self._conversation.join()
+                self._conversation = None
+        else:
+            self.logger.info("Stopping sandbox fallback loop")
+            self._stop_fallback.set()
+            thread = self._thread
+            if thread and thread.is_alive():
+                thread.join(timeout=1.0)
             self._thread = None
 
-    # Compatibility hook ----------------------------------------------------
+        self.voice.stop()
+        self._led_controller.set_color("idle")
+        self._running = False
+
+    def join(self, timeout: Optional[float] = None) -> None:
+        if self._conversation is not None:
+            self._conversation.join(timeout)
+        elif self._thread and self._thread.is_alive():
+            self._thread.join(timeout)
+            self._thread = None
+
     @property
-    def stop_event(self):  # pragma: no cover - compatibility stub
-        return None
+    def stop_event(self):
+        if self._conversation is not None:
+            return self._conversation.stop_event
+        return self._stop_fallback
 
 
 def build_services() -> tuple[AppServices, MockVisionService, MockMovementService, MockVoiceService, MockLedController]:
@@ -309,7 +748,7 @@ def build_services() -> tuple[AppServices, MockVisionService, MockMovementServic
     movement = MockMovementService()
     voice = MockVoiceService()
     led = MockLedController()
-    conversation = SandboxConversationService(voice, led)
+    conversation = CognitiveConversationService(voice, led)
     social_fsm = MockSocialFSM()
 
     services.vision = vision


### PR DESCRIPTION
## Summary
- replace the sandbox conversation loop with a cognitive version that can drive the real `ConversationService` when available
- add lightweight LLM client stubs, configuration loading, and a fallback loop to keep interaction running without a server
- register the new cognitive conversation service inside the sandbox service builder

## Testing
- python -m compileall sandbox/sandbox_runtime.py

------
https://chatgpt.com/codex/tasks/task_e_68e626391470832eb093e5bfb2d82da3