### PR TITLE
Use logger for WebSocket startup message

### DIFF
--- a/Server/app/runtime.py
+++ b/Server/app/runtime.py
@@ -310,7 +310,7 @@ class AppRuntime:
             return
 
         addr = ws_server._get_local_ip() if hasattr(ws_server, "_get_local_ip") else host
-        print(f"WebSocket listening at ws://{addr}:{port} ...")
+        logger.info("WebSocket listening at ws://%s:%s ...", addr, port)
 
         async with websockets.serve(handler, host, port):
             loop = asyncio.get_running_loop()


### PR DESCRIPTION
## Summary
- replace the direct print in _run_ws_server with the module logger to keep messaging consistent

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f4b3aae380832e87d7ae1134807411